### PR TITLE
Updated admin labels in UAE

### DIFF
--- a/data/137/682/638/7/1376826387.geojson
+++ b/data/137/682/638/7/1376826387.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":25.61713,
     "geom:longitude":56.269276,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u062f\u0628\u0627 \u0627\u0644\u062d\u0635\u0646\n"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Dibba Al-Hisn"
+    ],
     "lbl:latitude":25.616672,
     "lbl:longitude":56.268101,
     "mps:latitude":25.616672,
@@ -47,7 +53,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1548974954,
+    "wof:lastmodified":1561067877,
     "wof:name":"Dibba Al-Hisn",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/638/9/1376826389.geojson
+++ b/data/137/682/638/9/1376826389.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":24.890582,
     "geom:longitude":55.749255,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u0671\u0644\u0652\u0640\u0645\u064e\u0640\u062f\u064e\u0627\u0645\u200e"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Al Madam"
+    ],
     "lbl:latitude":24.889082,
     "lbl:longitude":55.738342,
     "mps:latitude":24.889082,
@@ -47,7 +53,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1548974032,
+    "wof:lastmodified":1561067877,
     "wof:name":"Al Madam",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/639/1/1376826391.geojson
+++ b/data/137/682/639/1/1376826391.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":25.194389,
     "geom:longitude":55.738141,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0628\u0637\u0627\u0626\u062d\n"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Al Bataeh"
+    ],
     "lbl:latitude":25.191472,
     "lbl:longitude":55.735575,
     "mps:latitude":25.191472,
@@ -47,7 +53,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1548974033,
+    "wof:lastmodified":1561067878,
     "wof:name":"Al Bataeh",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/639/3/1376826393.geojson
+++ b/data/137/682/639/3/1376826393.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":25.089107,
     "geom:longitude":55.890176,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u0645\u0644\u064a\u062d\u0629\n"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Mleeha"
+    ],
     "lbl:latitude":25.089853,
     "lbl:longitude":55.88322,
     "mps:latitude":25.089853,
@@ -47,7 +53,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1548974034,
+    "wof:lastmodified":1561067878,
     "wof:name":"Mleeha",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/639/7/1376826397.geojson
+++ b/data/137/682/639/7/1376826397.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":24.98632,
     "geom:longitude":56.268982,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u0643\u0644\u0628\u0627\u0621\u200e"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Kalba"
+    ],
     "lbl:latitude":24.939939,
     "lbl:longitude":56.22558,
     "mps:latitude":24.939939,
@@ -47,7 +53,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1548974035,
+    "wof:lastmodified":1561067879,
     "wof:name":"Kalba",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/640/1/1376826401.geojson
+++ b/data/137/682/640/1/1376826401.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":25.461758,
     "geom:longitude":55.55464,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u0627\ufedf\ufea4\ufee4\ufeae\ufef3\ufe94\u200e"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Al Hamriya"
+    ],
     "lbl:latitude":25.462064,
     "lbl:longitude":55.55464,
     "mps:latitude":25.462064,
@@ -47,7 +53,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1548974036,
+    "wof:lastmodified":1561067880,
     "wof:name":"Al Hamriya",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/640/3/1376826403.geojson
+++ b/data/137/682/640/3/1376826403.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":23.466859,
     "geom:longitude":53.321592,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u0628\u0644\u062f\u064a\u0629 \u0627\u0644\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u063a\u0631\u0628\u064a\u0629"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Al Gharbia"
+    ],
     "lbl:latitude":23.487464,
     "lbl:longitude":53.32153,
     "mps:latitude":23.487464,
@@ -47,7 +53,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1548974039,
+    "wof:lastmodified":1561067880,
     "wof:name":"Al Gharbia",
     "wof:parent_id":85667981,
     "wof:placetype":"county",

--- a/data/137/683/360/3/1376833603.geojson
+++ b/data/137/683/360/3/1376833603.geojson
@@ -11,6 +11,12 @@
     "geom:longitude":55.371022,
     "gn:population":1141963,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u062f\u0628\u064a"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Dubai"
+    ],
     "lbl:latitude":24.891256,
     "lbl:longitude":55.348249,
     "mps:latitude":24.891256,
@@ -591,7 +597,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1548974120,
+    "wof:lastmodified":1561067881,
     "wof:name":"Dubai",
     "wof:parent_id":85667983,
     "wof:placetype":"county",

--- a/data/137/683/360/5/1376833605.geojson
+++ b/data/137/683/360/5/1376833605.geojson
@@ -10,6 +10,13 @@
     "geom:latitude":25.455723,
     "geom:longitude":56.033426,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629",
+        "\u0631\u0623\u0633 \u0627\u0644\u062e\u064a\u0645\u0629"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Ras al Khaimah"
+    ],
     "lbl:latitude":25.694165,
     "lbl:longitude":55.977945,
     "mps:latitude":25.694165,
@@ -392,7 +399,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1548974127,
+    "wof:lastmodified":1561067881,
     "wof:name":"Ras Al Khaimah",
     "wof:parent_id":85667951,
     "wof:placetype":"county",

--- a/data/137/683/360/7/1376833607.geojson
+++ b/data/137/683/360/7/1376833607.geojson
@@ -11,6 +11,12 @@
     "geom:longitude":55.60629,
     "gn:population":234905,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u0639\u062c\u0645\u0627\u0646"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Ajman"
+    ],
     "lbl:latitude":25.40703,
     "lbl:longitude":55.514075,
     "mps:latitude":25.40703,
@@ -361,7 +367,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1548974130,
+    "wof:lastmodified":1561067882,
     "wof:name":"Ajman",
     "wof:parent_id":85667969,
     "wof:placetype":"county",

--- a/data/137/683/360/9/1376833609.geojson
+++ b/data/137/683/360/9/1376833609.geojson
@@ -11,6 +11,12 @@
     "geom:longitude":55.735502,
     "gn:population":56253,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u0623\u0645 \u0627\u0644\u0642\u064a\u0648\u064a\u0646"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Umm Al Quwain"
+    ],
     "lbl:latitude":25.529773,
     "lbl:longitude":55.718237,
     "mps:latitude":25.529773,
@@ -397,7 +403,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1548974132,
+    "wof:lastmodified":1561067882,
     "wof:name":"Umm Al Quwain",
     "wof:parent_id":85667955,
     "wof:placetype":"county",

--- a/data/137/683/361/1/1376833611.geojson
+++ b/data/137/683/361/1/1376833611.geojson
@@ -11,6 +11,12 @@
     "geom:longitude":56.197444,
     "gn:population":113316,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0641\u062c\u064a\u0631\u0629"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Fujairah"
+    ],
     "lbl:latitude":25.488009,
     "lbl:longitude":56.237778,
     "mps:latitude":25.488009,
@@ -346,7 +352,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1548974137,
+    "wof:lastmodified":1561067883,
     "wof:name":"Fujairah",
     "wof:parent_id":85667959,
     "wof:placetype":"county",

--- a/data/421/171/391/421171391.geojson
+++ b/data/421/171/391/421171391.geojson
@@ -10,13 +10,232 @@
     "geom:latitude":25.322024,
     "geom:longitude":55.555589,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0634\u0627\u0631\u0642\u0629"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Sharjah"
+    ],
     "lbl:latitude":25.290081,
     "lbl:longitude":55.597165,
     "mps:latitude":25.290081,
     "mps:longitude":55.597165,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:note":"quattroshapes points import (201603)",
+    "name:alb_x_preferred":[
+        "Sharxha"
+    ],
+    "name:ara_x_preferred":[
+        "\u0625\u0645\u0627\u0631\u0629 \u0627\u0644\u0634\u0627\u0631\u0642\u0629"
+    ],
+    "name:ara_x_variant":[
+        "\u0627\u0644\u0634\u0627\u0631\u0642\u0629"
+    ],
+    "name:arm_x_preferred":[
+        "\u0547\u0561\u0580\u056a\u0561"
+    ],
+    "name:aze_x_preferred":[
+        "\u015earja"
+    ],
+    "name:baq_x_preferred":[
+        "Xarja"
+    ],
+    "name:bel_x_preferred":[
+        "\u0413\u043e\u0440\u0430\u0434 \u0428\u0430\u0440\u0434\u0436\u0430"
+    ],
+    "name:bre_x_preferred":[
+        "Charjah"
+    ],
+    "name:bul_x_preferred":[
+        "\u0428\u0430\u0440\u0434\u0436\u0430"
+    ],
+    "name:cat_x_preferred":[
+        "Xarjah"
+    ],
+    "name:ces_x_preferred":[
+        "\u0160ard\u017e\u00e1"
+    ],
+    "name:chi_x_preferred":[
+        "\u6c99\u8fe6"
+    ],
+    "name:cze_x_preferred":[
+        "\u0160ard\u017e\u00e1"
+    ],
+    "name:dan_x_preferred":[
+        "Sharjah"
+    ],
+    "name:deu_x_preferred":[
+        "Schardscha"
+    ],
+    "name:dut_x_preferred":[
+        "Sharjah"
+    ],
+    "name:eng_x_preferred":[
+        "Sharjah"
+    ],
+    "name:epo_x_preferred":[
+        "\u015car\u0135o"
+    ],
+    "name:est_x_preferred":[
+        "Ash-Sh\u0101riqah emiraat"
+    ],
+    "name:eus_x_preferred":[
+        "Xarja"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0627\u0631\u062c\u0647"
+    ],
+    "name:fin_x_preferred":[
+        "Sharja"
+    ],
+    "name:fra_x_preferred":[
+        "Charjah"
+    ],
+    "name:fre_x_preferred":[
+        "Charjah"
+    ],
+    "name:frp_x_preferred":[
+        "Ch\u00b7ardj\u00b7a"
+    ],
+    "name:geo_x_preferred":[
+        "\u10e8\u10d0\u10e0\u10ef\u10d0"
+    ],
+    "name:ger_x_preferred":[
+        "Schardscha"
+    ],
+    "name:hbs_x_preferred":[
+        "\u0160ard\u017ea"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e9\u05d0\u05e8\u05d2\u05d4"
+    ],
+    "name:hin_x_preferred":[
+        "\u0936\u093e\u0930\u091c\u093e\u0939"
+    ],
+    "name:hun_x_preferred":[
+        "Sardzsa"
+    ],
+    "name:hye_x_preferred":[
+        "\u0547\u0561\u0580\u056a\u0561"
+    ],
+    "name:ind_x_preferred":[
+        "Sharjah"
+    ],
+    "name:ita_x_preferred":[
+        "Sharja"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b7\u30e3\u30fc\u30eb\u30b8\u30e3"
+    ],
+    "name:kal_x_preferred":[
+        "Sharjah"
+    ],
+    "name:kan_x_preferred":[
+        "\u0cb6\u0cbe\u0cb0\u0ccd\u0c9c"
+    ],
+    "name:kat_x_preferred":[
+        "\u10e8\u10d0\u10e0\u10ef\u10d0"
+    ],
+    "name:kor_x_preferred":[
+        "\uc0e4\ub974\uc790"
+    ],
+    "name:lit_x_preferred":[
+        "\u0160ard\u017ea"
+    ],
+    "name:ltz_x_preferred":[
+        "Schardscha"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d37\u0d3e\u0d7c\u0d1c"
+    ],
+    "name:mar_x_preferred":[
+        "\u0936\u093e\u0930\u091c\u093e"
+    ],
+    "name:nld_x_preferred":[
+        "Sharjah"
+    ],
+    "name:nno_x_preferred":[
+        "Sharjah"
+    ],
+    "name:nob_x_preferred":[
+        "Sharjah"
+    ],
+    "name:pan_x_preferred":[
+        "\u0a38\u0a3c\u0a3e\u0a30\u0a1c\u0a3e"
+    ],
+    "name:per_x_preferred":[
+        "\u0634\u0627\u0631\u062c\u0647"
+    ],
+    "name:pnb_x_preferred":[
+        "\u0634\u0627\u0631\u062c\u06c1"
+    ],
+    "name:pol_x_preferred":[
+        "Szard\u017ca"
+    ],
+    "name:por_x_preferred":[
+        "Sharjah"
+    ],
+    "name:ron_x_preferred":[
+        "Sharjah"
+    ],
+    "name:rum_x_preferred":[
+        "Sharjah"
+    ],
+    "name:rus_x_preferred":[
+        "\u0428\u0430\u0440\u0434\u0436\u0430"
+    ],
+    "name:sah_x_preferred":[
+        "\u0428\u0430\u0440\u0434\u0436\u0430 \u043a\u0443\u043e\u0440\u0430\u0442"
+    ],
+    "name:sco_x_preferred":[
+        "Sharjah"
+    ],
+    "name:spa_x_preferred":[
+        "Sarja"
+    ],
+    "name:srp_x_preferred":[
+        "\u0428\u0430\u0440\u045f\u0430"
+    ],
+    "name:swe_x_preferred":[
+        "Sharjah"
+    ],
+    "name:tam_x_preferred":[
+        "\u0b9a\u0bbe\u0bb0\u0bcd\u0b9c\u0bbe"
+    ],
+    "name:tat_x_preferred":[
+        "\u0428\u0430\u0440\u0497\u04d9"
+    ],
+    "name:tel_x_preferred":[
+        "\u0c37\u0c3e\u0c30\u0c4d\u0c1c\u0c3e"
+    ],
+    "name:tgl_x_preferred":[
+        "Sharjah"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e0a\u0e32\u0e23\u0e4c\u0e08\u0e32\u0e2b\u0e4c"
+    ],
+    "name:tur_x_preferred":[
+        "\u015earika"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0428\u0430\u0440\u0434\u0436\u0430"
+    ],
+    "name:unk_x_variant":[
+        "Ash Sh\u0101riqah"
+    ],
+    "name:urd_x_preferred":[
+        "\u0634\u0627\u0631\u062c\u06c1"
+    ],
+    "name:war_x_preferred":[
+        "Sharjah"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10e8\u10d0\u10e0\u10ef\u10d0"
+    ],
+    "name:zho_x_preferred":[
+        "\u590f\u5c14\u8fe6"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -63,8 +282,8 @@
         }
     ],
     "wof:id":421171391,
-    "wof:lastmodified":1548974151,
-    "wof:name":"\u0627\u0644\u0634\u0627\u0631\u0642\u0629",
+    "wof:lastmodified":1561067884,
+    "wof:name":"Sharjah",
     "wof:parent_id":85667977,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/172/075/421172075.geojson
+++ b/data/421/172/075/421172075.geojson
@@ -10,13 +10,491 @@
     "geom:latitude":24.157517,
     "geom:longitude":54.597557,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u0623\u0628\u0648\u0638\u0628\u064a"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Abu Dhabi"
+    ],
     "lbl:latitude":24.028302,
     "lbl:longitude":54.524528,
     "mps:latitude":24.028302,
     "mps:longitude":54.524528,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ace_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:afr_x_preferred":[
+        "Aboe Dhabi"
+    ],
+    "name:alb_x_preferred":[
+        "Abu Dabi"
+    ],
+    "name:amh_x_preferred":[
+        "\u12a0\u1261 \u12f3\u1262"
+    ],
+    "name:ang_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:ara_x_preferred":[
+        "\u0623\u0628\u0648\u0638\u0628\u064a"
+    ],
+    "name:arm_x_preferred":[
+        "\u0531\u0562\u0578\u0582 \u0534\u0561\u0562\u056b"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0628\u0648 \u0638\u0628\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Abu Dabi"
+    ],
+    "name:aym_x_preferred":[
+        "Abu Dhabi Marka"
+    ],
+    "name:azb_x_preferred":[
+        "\u0627\u0628\u0648\u0638\u0628\u06cc"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fbu-Dabi"
+    ],
+    "name:bak_x_preferred":[
+        "\u04d8\u0431\u04af-\u0414\u04d9\u0431\u0438"
+    ],
+    "name:baq_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:bcl_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:bel_x_preferred":[
+        "\u0413\u043e\u0440\u0430\u0434 \u0410\u0431\u0443-\u0414\u0430\u0431\u0456"
+    ],
+    "name:ben_x_preferred":[
+        "\u0986\u09ac\u09c1\u09a7\u09be\u09ac\u09bf"
+    ],
+    "name:bjn_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:bod_x_preferred":[
+        "\u0f68\u0f0b\u0f54\u0f7c\u0f60\u0f74\u0f0b\u0f51\u0fb7\u0f0b\u0f54\u0f7a\u0f0d"
+    ],
+    "name:bos_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:bre_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:bul_x_preferred":[
+        "\u0410\u0431\u0443 \u0414\u0430\u0431\u0438"
+    ],
+    "name:bur_x_preferred":[
+        "\u1021\u1018\u1030\u1012\u102b\u1018\u102e\u1019\u103c\u102d\u102f\u1037"
+    ],
+    "name:bxr_x_preferred":[
+        "\u0410\u0431\u0443-\u0414\u0430\u0431\u0438"
+    ],
+    "name:cat_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:cdo_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:ces_x_preferred":[
+        "Ab\u00fa Zab\u00ed"
+    ],
+    "name:che_x_preferred":[
+        "\u0410\u0431\u0443-\u0414\u0430\u0431\u0438"
+    ],
+    "name:chi_x_preferred":[
+        "\u963f\u5e03\u624e\u6bd4"
+    ],
+    "name:ckb_x_preferred":[
+        "\u0626\u06d5\u0628\u0648\u0648\u0632\u06d5\u0628\u06cc"
+    ],
+    "name:cze_x_preferred":[
+        "Ab\u00fa Zab\u00ed"
+    ],
+    "name:dan_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:deu_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:diq_x_preferred":[
+        "Ebu Dabi"
+    ],
+    "name:dty_x_preferred":[
+        "\u0905\u092c\u0941\u0927\u093e\u092c\u0940"
+    ],
+    "name:dut_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u03bc\u03c0\u03bf\u03cd \u039d\u03c4\u03ac\u03bc\u03c0\u03b9"
+    ],
+    "name:ell_x_variant":[
+        "\u0391\u03bc\u03c0\u03bf\u03c5 \u039d\u03c4\u03b1\u03bc\u03c0\u03b9",
+        "\u0386\u03bc\u03c0\u03bf\u03c5 \u039d\u03c4\u03ac\u03bc\u03c0\u03b9"
+    ],
+    "name:eng_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:epo_x_preferred":[
+        "Abu-Dabio"
+    ],
+    "name:est_x_preferred":[
+        "Abu Dhabi emiraat"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0628\u0648\u0638\u0628\u06cc"
+    ],
+    "name:fin_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:fra_x_preferred":[
+        "Abou Dabi"
+    ],
+    "name:fre_x_preferred":[
+        "Abou Dabi"
+    ],
+    "name:frp_x_preferred":[
+        "Abou Dabi"
+    ],
+    "name:fry_x_preferred":[
+        "Ab\u00fb Daby"
+    ],
+    "name:geo_x_preferred":[
+        "\u10d0\u10d1\u10e3-\u10d3\u10d0\u10d1\u10d8"
+    ],
+    "name:ger_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:gla_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:gle_x_preferred":[
+        "Ab\u00fa Daib\u00ed"
+    ],
+    "name:glg_x_preferred":[
+        "Abu Zabi"
+    ],
+    "name:gre_x_preferred":[
+        "\u0386\u03bc\u03c0\u03bf\u03c5 \u039d\u03c4\u03ac\u03bc\u03c0\u03b9"
+    ],
+    "name:gsw_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:guj_x_preferred":[
+        "\u0a85\u0aac\u0ac1 \u0aa7\u0abe\u0aac\u0ac0"
+    ],
+    "name:hak_x_preferred":[
+        "\u00c2-pu-tha\u030dt-p\u00ed"
+    ],
+    "name:hat_x_preferred":[
+        "Abou Dabi"
+    ],
+    "name:hbs_x_preferred":[
+        "Abu Dabi"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05d1\u05d5 \u05d3\u05d0\u05d1\u05d9"
+    ],
+    "name:hif_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:hin_x_preferred":[
+        "\u0905\u092c\u0942 \u0927\u093e\u092c\u0940"
+    ],
+    "name:hrv_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:hun_x_preferred":[
+        "Abu-Dzabi"
+    ],
+    "name:hye_x_preferred":[
+        "\u0531\u0562\u0578\u0582 \u0534\u0561\u0562\u056b"
+    ],
+    "name:ice_x_preferred":[
+        "Ab\u00fa Dab\u00ed"
+    ],
+    "name:ido_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:ile_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:ind_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:isl_x_preferred":[
+        "Ab\u00fa Dab\u00ed"
+    ],
+    "name:ita_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:jav_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a2\u30d6\u30c0\u30d3"
+    ],
+    "name:kaa_x_preferred":[
+        "Abu Dabi"
+    ],
+    "name:kab_x_preferred":[
+        "Abu \u1e0cabi"
+    ],
+    "name:kal_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:kan_x_preferred":[
+        "\u0c85\u0cac\u0cc1 \u0ca7\u0cbe\u0cac\u0cbf"
+    ],
+    "name:kat_x_preferred":[
+        "\u10d0\u10d1\u10e3-\u10d3\u10d0\u10d1\u10d8"
+    ],
+    "name:kaz_x_preferred":[
+        "\u0410\u0431\u0443-\u0414\u0430\u0431\u0438"
+    ],
+    "name:kik_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:kir_x_preferred":[
+        "\u0410\u0431\u0443-\u0414\u0430\u0431\u0438"
+    ],
+    "name:kor_x_preferred":[
+        "\uc544\ubd80\ub2e4\ube44"
+    ],
+    "name:kur_x_preferred":[
+        "Ab\u00fb Zeb\u00ee"
+    ],
+    "name:lat_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:lav_x_preferred":[
+        "Ab\u016b Dab\u012b"
+    ],
+    "name:lit_x_preferred":[
+        "Abu Dabis"
+    ],
+    "name:lmo_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:lrc_x_preferred":[
+        "\u0627\u0628\u0648\u0638\u0628\u06cc"
+    ],
+    "name:ltz_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:lzh_x_preferred":[
+        "\u963f\u5e03\u624e\u6bd4"
+    ],
+    "name:mac_x_preferred":[
+        "\u0410\u0431\u0443 \u0414\u0430\u0431\u0438"
+    ],
+    "name:mai_x_preferred":[
+        "\u0905\u092c\u0942 \u0927\u093e\u092c\u0940"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d05\u0d2c\u0d41\u0d26\u0d3e\u0d2c\u0d3f"
+    ],
+    "name:mar_x_preferred":[
+        "\u0905\u092c\u0941 \u0927\u093e\u092c\u0940"
+    ],
+    "name:may_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0410\u0431\u0443 \u0414\u0430\u0431\u0438"
+    ],
+    "name:mon_x_preferred":[
+        "\u0410\u0431\u0443-\u0414\u0430\u0431\u0438 \u0445\u043e\u0442"
+    ],
+    "name:mya_x_preferred":[
+        "\u1021\u1018\u1030\u1012\u102b\u1018\u102e\u1019\u103c\u102d\u102f\u1037"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0627\u0628\u0648\u0638\u0628\u06cc"
+    ],
+    "name:nan_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:nep_x_preferred":[
+        "\u0905\u092c\u0942 \u0927\u093e\u092c\u0940"
+    ],
+    "name:nld_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:nno_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:nob_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:nor_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:nov_x_preferred":[
+        "Abu Dabi"
+    ],
+    "name:oci_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:ori_x_preferred":[
+        "\u0b06\u0b2c\u0b41\u0b27\u0b3e\u0b2c\u0b3f"
+    ],
+    "name:oss_x_preferred":[
+        "\u0410\u0431\u0443-\u0414\u0430\u0431\u0438"
+    ],
+    "name:pam_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:pan_x_preferred":[
+        "\u0a05\u0a2c\u0a42 \u0a27\u0a3e\u0a2c\u0a40"
+    ],
+    "name:pap_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:per_x_preferred":[
+        "\u0627\u0628\u0648\u0638\u0628\u06cc"
+    ],
+    "name:pms_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:pnb_x_preferred":[
+        "\u0627\u0628\u0648\u0638\u06c1\u0628\u06cc"
+    ],
+    "name:pol_x_preferred":[
+        "Abu Zabi"
+    ],
+    "name:por_x_preferred":[
+        "Abu Dabi"
+    ],
+    "name:rum_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:rup_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u0431\u0443-\u0414\u0430\u0431\u0438"
+    ],
+    "name:sah_x_preferred":[
+        "\u0410\u0431\u0443 \u0414\u0430\u0431\u0438"
+    ],
+    "name:scn_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:sco_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:sgs_x_preferred":[
+        "Abu Dabis"
+    ],
+    "name:sin_x_preferred":[
+        "\u0d85\u0db6\u0dd4\u0da9\u0dcf\u0db6\u0dd2"
+    ],
+    "name:slk_x_preferred":[
+        "Ab\u00fa Zab\u00ed"
+    ],
+    "name:slo_x_preferred":[
+        "Ab\u00fa Zab\u00ed"
+    ],
+    "name:slv_x_preferred":[
+        "Abu Dabi"
+    ],
+    "name:sna_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:som_x_preferred":[
+        "Abu Dabi"
+    ],
+    "name:spa_x_preferred":[
+        "Abu Dabi"
+    ],
+    "name:sqi_x_preferred":[
+        "Ebu Dhabi"
+    ],
+    "name:srp_x_preferred":[
+        "\u0410\u0431\u0443 \u0414\u0430\u0431\u0438"
+    ],
+    "name:swa_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:swe_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:tam_x_preferred":[
+        "\u0b85\u0baa\u0bc1\u0ba4\u0bbe\u0baa\u0bbf"
+    ],
+    "name:tat_x_preferred":[
+        "\u04d8\u0431\u0443-\u0414\u0430\u0431\u0438"
+    ],
+    "name:tel_x_preferred":[
+        "\u0c05\u0c2c\u0c42\u0c27\u0c3e\u0c2c\u0c40"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0410\u0431\u0443 \u0414\u0430\u0431\u0438"
+    ],
+    "name:tgl_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e2d\u0e32\u0e1a\u0e39\u0e14\u0e32\u0e1a\u0e35"
+    ],
+    "name:tib_x_preferred":[
+        "\u0f68\u0f0b\u0f54\u0f7c\u0f60\u0f74\u0f0b\u0f51\u0fb7\u0f0b\u0f54\u0f7a\u0f0d"
+    ],
+    "name:tuk_x_preferred":[
+        "Abu-dabi"
+    ],
+    "name:tur_x_preferred":[
+        "Abu Dabi"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0410\u0431\u0443-\u0414\u0430\u0431\u0456"
+    ],
+    "name:unk_x_variant":[
+        "Ab\u016b Z\u0327aby"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0628\u0648\u0638\u0628\u06cc"
+    ],
+    "name:uzb_x_preferred":[
+        "Abu-Dabi"
+    ],
+    "name:vep_x_preferred":[
+        "Abu Dabi"
+    ],
+    "name:vie_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:vol_x_preferred":[
+        "\u00c4bu Saby"
+    ],
+    "name:vro_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:war_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:wel_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10d0\u10d1\u10e3-\u10d3\u10d0\u10d1\u10d8"
+    ],
+    "name:yor_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:yue_x_preferred":[
+        "\u963f\u5e03\u624e\u6bd4"
+    ],
+    "name:zho_x_preferred":[
+        "\u963f\u5e03\u624e\u6bd4"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -63,8 +541,8 @@
         }
     ],
     "wof:id":421172075,
-    "wof:lastmodified":1548974158,
-    "wof:name":"\u0623\u0628\u0648\u0638\u0628\u064a",
+    "wof:lastmodified":1561067884,
+    "wof:name":"Abu Dhabi",
     "wof:parent_id":85667981,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/172/075/421172075.geojson
+++ b/data/421/172/075/421172075.geojson
@@ -11,7 +11,7 @@
     "geom:longitude":54.597557,
     "iso:country":"AE",
     "label:ara_x_preferred_longname":[
-        "\u0623\u0628\u0648\u0638\u0628\u064a"
+        "\u0623\u0628\u0648 \u0638\u0628\u064a"
     ],
     "label:eng_x_preferred_longname":[
         "Abu Dhabi"
@@ -39,6 +39,9 @@
         "Abu Dhabi"
     ],
     "name:ara_x_preferred":[
+        "\u0623\u0628\u0648 \u0638\u0628\u064a"
+    ],
+    "name:ara_x_variant":[
         "\u0623\u0628\u0648\u0638\u0628\u064a"
     ],
     "name:arm_x_preferred":[
@@ -541,7 +544,7 @@
         }
     ],
     "wof:id":421172075,
-    "wof:lastmodified":1561067884,
+    "wof:lastmodified":1561485356,
     "wof:name":"Abu Dhabi",
     "wof:parent_id":85667981,
     "wof:placetype":"county",

--- a/data/421/176/643/421176643.geojson
+++ b/data/421/176/643/421176643.geojson
@@ -10,13 +10,52 @@
     "geom:latitude":25.253523,
     "geom:longitude":55.915569,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0630\u064a\u062f"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Dhaid"
+    ],
     "lbl:latitude":25.234748,
     "lbl:longitude":55.909484,
     "mps:latitude":25.234748,
     "mps:longitude":55.909484,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0630\u064a\u062f"
+    ],
+    "name:cat_x_preferred":[
+        "Dhaid"
+    ],
+    "name:chi_x_preferred":[
+        "\u9054\u4f0a\u5fb7"
+    ],
+    "name:dut_x_preferred":[
+        "Dhaid"
+    ],
+    "name:eng_x_preferred":[
+        "Dhaid"
+    ],
+    "name:nno_x_preferred":[
+        "Dhaid"
+    ],
+    "name:per_x_preferred":[
+        "\u0630\u06cc\u062f"
+    ],
+    "name:pol_x_preferred":[
+        "Az-Zajd"
+    ],
+    "name:swe_x_preferred":[
+        "Adh Dhayd"
+    ],
+    "name:unk_x_variant":[
+        "Dhaid"
+    ],
+    "name:urd_x_preferred":[
+        "\u0630\u06cc\u062f"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -63,8 +102,8 @@
         }
     ],
     "wof:id":421176643,
-    "wof:lastmodified":1548974162,
-    "wof:name":"\u0627\u0644\u0630\u064a\u062f",
+    "wof:lastmodified":1561067885,
+    "wof:name":"Dhaid",
     "wof:parent_id":85667977,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/182/269/421182269.geojson
+++ b/data/421/182/269/421182269.geojson
@@ -10,13 +10,88 @@
     "geom:latitude":25.333921,
     "geom:longitude":56.304181,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u0645\u062f\u064a\u0646\u0629 \u062e\u0648\u0631 \u0641\u0643\u0627\u0646"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Khor Fakkan"
+    ],
     "lbl:latitude":25.347699,
     "lbl:longitude":56.319681,
     "mps:latitude":25.347699,
     "mps:longitude":56.319681,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u062f\u064a\u0646\u0629 \u062e\u0648\u0631 \u0641\u0643\u0627\u0646"
+    ],
+    "name:arm_x_preferred":[
+        "\u053d\u0578\u0580-\u0556\u0561\u056f\u056f\u0561\u0576"
+    ],
+    "name:cat_x_preferred":[
+        "Khor Fakkan"
+    ],
+    "name:chi_x_preferred":[
+        "\u8c6a\u723e\u8cbb\u574e"
+    ],
+    "name:cze_x_preferred":[
+        "Ch\u00f3r Fakk\u00e1n"
+    ],
+    "name:dut_x_preferred":[
+        "Khor Fakkan"
+    ],
+    "name:eng_x_preferred":[
+        "Khor Fakkan"
+    ],
+    "name:eng_x_variant":[
+        "Khor'fakkan"
+    ],
+    "name:fre_x_preferred":[
+        "Khor Fakkan"
+    ],
+    "name:ger_x_preferred":[
+        "Chaur Fakkan"
+    ],
+    "name:ita_x_preferred":[
+        "Khawr Fakk\u0101n"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30db\u30fc\u30eb\u30fb\u30d5\u30a1\u30ab\u30f3"
+    ],
+    "name:lit_x_preferred":[
+        "Chor Fakanas"
+    ],
+    "name:nno_x_preferred":[
+        "Khor Fakkan"
+    ],
+    "name:nob_x_preferred":[
+        "Khor Fakkan"
+    ],
+    "name:per_x_preferred":[
+        "\u062e\u0648\u0631 \u0641\u06a9\u0627\u0646"
+    ],
+    "name:pol_x_preferred":[
+        "Chur Fakkan"
+    ],
+    "name:rus_x_preferred":[
+        "\u0425\u043e\u0440-\u0424\u0430\u043a\u043a\u0430\u043d"
+    ],
+    "name:swe_x_preferred":[
+        "Khawr Fakk\u0101n"
+    ],
+    "name:tam_x_preferred":[
+        "\u0b95\u0bcb\u0bb0\u0bcd\u0baa\u0b95\u0bcd\u0b95\u0bbe\u0ba9\u0bcd"
+    ],
+    "name:tgl_x_preferred":[
+        "Khawr Fakkan"
+    ],
+    "name:unk_x_variant":[
+        "Khor al Fakkan"
+    ],
+    "name:urd_x_preferred":[
+        "\u062e\u0648\u0631\u0641\u06a9\u0627\u0646"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -63,8 +138,8 @@
         }
     ],
     "wof:id":421182269,
-    "wof:lastmodified":1548974167,
-    "wof:name":"\u0645\u062f\u064a\u0646\u0629 \u062e\u0648\u0631 \u0641\u0643\u0627\u0646",
+    "wof:lastmodified":1561067885,
+    "wof:name":"Khor Fakkan",
     "wof:parent_id":85667977,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/200/931/421200931.geojson
+++ b/data/421/200/931/421200931.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":23.708046,
     "geom:longitude":55.224452,
     "iso:country":"AE",
+    "label:ara_x_preferred_longname":[
+        "\u0627\u0644\u0639\u064a\u0646"
+    ],
+    "label:eng_x_preferred_longname":[
+        "Al Ain"
+    ],
     "lbl:latitude":23.688012,
     "lbl:longitude":55.235742,
     "mps:latitude":23.688012,
@@ -17,6 +23,220 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0639\u064a\u0646"
+    ],
+    "name:ara_x_variant":[
+        "Al \u2018Ayn",
+        "\u0627\u0644\u0639\u064a\u0646\u060c \u0623\u0628\u0648\u0638\u0628\u064a"
+    ],
+    "name:arm_x_preferred":[
+        "\u0531\u056c-\u0531\u0575\u056b\u0576"
+    ],
+    "name:baq_x_preferred":[
+        "Al Ain"
+    ],
+    "name:ben_x_preferred":[
+        "\u0986\u09b2 \u0986\u0987\u09a8"
+    ],
+    "name:cat_x_preferred":[
+        "Al-Ain"
+    ],
+    "name:ces_x_preferred":[
+        "Al Ajn"
+    ],
+    "name:chi_x_preferred":[
+        "\u827e\u56e0"
+    ],
+    "name:cze_x_preferred":[
+        "Al Ajn"
+    ],
+    "name:dan_x_preferred":[
+        "Al-Ain"
+    ],
+    "name:deu_x_preferred":[
+        "Al-Ain"
+    ],
+    "name:dut_x_preferred":[
+        "Al Ain"
+    ],
+    "name:eng_x_preferred":[
+        "Al Ain"
+    ],
+    "name:epo_x_preferred":[
+        "El-Ajn"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0639\u06cc\u0646"
+    ],
+    "name:fin_x_preferred":[
+        "Al-Ain"
+    ],
+    "name:fra_x_preferred":[
+        "Al-A\u00efn"
+    ],
+    "name:fre_x_preferred":[
+        "Al-A\u00efn"
+    ],
+    "name:geo_x_preferred":[
+        "\u10d0\u10da-\u10d0\u10d8\u10dc\u10d8"
+    ],
+    "name:ger_x_preferred":[
+        "Al-Ain"
+    ],
+    "name:gre_x_preferred":[
+        "\u0391\u03bb \u0386\u03b9\u03bd"
+    ],
+    "name:guj_x_preferred":[
+        "\u0a85\u0ab2 \u0a86\u0a88\u0aa8"
+    ],
+    "name:hbs_x_preferred":[
+        "Al-Ain"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05dc-\u05e2\u05d9\u05df"
+    ],
+    "name:hin_x_preferred":[
+        "\u0905\u0932 \u0910\u0928"
+    ],
+    "name:hrv_x_preferred":[
+        "Al Ain"
+    ],
+    "name:hun_x_preferred":[
+        "El-Ajn"
+    ],
+    "name:hye_x_preferred":[
+        "\u0531\u056c-\u0531\u0575\u056b\u0576"
+    ],
+    "name:ind_x_preferred":[
+        "Al Ain"
+    ],
+    "name:ita_x_preferred":[
+        "Al-Ayn"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a2\u30eb\u30fb\u30a2\u30a4\u30f3"
+    ],
+    "name:kab_x_preferred":[
+        "Al \u0190ayn"
+    ],
+    "name:kal_x_preferred":[
+        "Al Ain"
+    ],
+    "name:kan_x_preferred":[
+        "\u0c85\u0cb2\u0ccd \u0c90\u0ca8\u0ccd"
+    ],
+    "name:kat_x_preferred":[
+        "\u10d0\u10da-\u10d0\u10d8\u10dc\u10d8"
+    ],
+    "name:kor_x_preferred":[
+        "\uc54c\uc544\uc778"
+    ],
+    "name:lav_x_preferred":[
+        "Al-Aina"
+    ],
+    "name:lit_x_preferred":[
+        "Ainas"
+    ],
+    "name:lmo_x_preferred":[
+        "Al Ain"
+    ],
+    "name:ltz_x_preferred":[
+        "Al Ain"
+    ],
+    "name:mai_x_preferred":[
+        "\u0905\u0932 \u0910\u0928"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d05\u0d7d \u0d10\u0d7b"
+    ],
+    "name:mar_x_preferred":[
+        "\u0905\u0932 \u0910\u0928"
+    ],
+    "name:may_x_preferred":[
+        "Al Ain"
+    ],
+    "name:nep_x_preferred":[
+        "\u090f\u0932 \u090f\u0928"
+    ],
+    "name:nno_x_preferred":[
+        "Al Ain"
+    ],
+    "name:nob_x_preferred":[
+        "Al Ain"
+    ],
+    "name:per_x_preferred":[
+        "\u0627\u0644\u0639\u06cc\u0646"
+    ],
+    "name:pnb_x_preferred":[
+        "\u0627\u0644\u0639\u06cc\u0646"
+    ],
+    "name:pol_x_preferred":[
+        "Al-Ajn"
+    ],
+    "name:por_x_preferred":[
+        "Al Ain"
+    ],
+    "name:rum_x_preferred":[
+        "Al Ain"
+    ],
+    "name:rus_x_preferred":[
+        "\u042d\u043b\u044c-\u0410\u0439\u043d"
+    ],
+    "name:sco_x_preferred":[
+        "Al Ain"
+    ],
+    "name:sin_x_preferred":[
+        "\u0d85\u0dbd\u0dca \u0d85\u0dba\u0dd2\u0db1\u0dca"
+    ],
+    "name:spa_x_preferred":[
+        "Al Ain"
+    ],
+    "name:srp_x_preferred":[
+        "\u0415\u043b \u0410\u0438\u043d"
+    ],
+    "name:swe_x_preferred":[
+        "Al Ain"
+    ],
+    "name:tam_x_preferred":[
+        "\u0b85\u0bb2\u0bcd \u0b90\u0ba9\u0bcd"
+    ],
+    "name:tel_x_preferred":[
+        "\u0c05\u0c32\u0c4d\u0c10\u0c28\u0c4d"
+    ],
+    "name:tgl_x_preferred":[
+        "Al Ain"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e2d\u0e31\u0e25 \u0e44\u0e2d\u0e19\u0e4c"
+    ],
+    "name:tur_x_preferred":[
+        "Al Ain"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0415\u043b\u044c-\u0410\u0439\u043d"
+    ],
+    "name:unk_x_variant":[
+        "Al Ain"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0639\u06cc\u0646"
+    ],
+    "name:uzb_x_preferred":[
+        "Al Ayn"
+    ],
+    "name:vep_x_preferred":[
+        "El Ain"
+    ],
+    "name:vie_x_preferred":[
+        "Al Ain"
+    ],
+    "name:war_x_preferred":[
+        "Al-A\u00efn"
+    ],
+    "name:zho_x_preferred":[
+        "\u827e\u56e0"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -63,8 +283,8 @@
         }
     ],
     "wof:id":421200931,
-    "wof:lastmodified":1548974183,
-    "wof:name":"\u0627\u0644\u0639\u064a\u0646",
+    "wof:lastmodified":1561067886,
+    "wof:name":"Al Ain",
     "wof:parent_id":85667981,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/856/679/63/85667963.geojson
+++ b/data/856/679/63/85667963.geojson
@@ -10,8 +10,14 @@
     "geom:latitude":24.92636,
     "geom:longitude":56.291629,
     "iso:country":"AE",
+    "label:ara_x_preferred_placetype":[
+        "\u0625\u0645\u0627\u0631\u0629"
+    ],
     "label:eng_x_preferred_longname":[
-        "Neutral Zone Emirate"
+        "Neutral Zone"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "emirate"
     ],
     "lbl:latitude":24.92465,
     "lbl:longitude":56.289785,
@@ -119,7 +125,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550292,
+    "wof:lastmodified":1561066238,
     "wof:name":"Neutral Zone",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/73/85667973.geojson
+++ b/data/856/679/73/85667973.geojson
@@ -10,8 +10,14 @@
     "geom:latitude":24.817533,
     "geom:longitude":56.038297,
     "iso:country":"AE",
+    "label:ara_x_preferred_placetype":[
+        "\u0625\u0645\u0627\u0631\u0629"
+    ],
     "label:eng_x_preferred_longname":[
-        "Neutral Zone Emirate"
+        "Neutral Zone"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "emirate"
     ],
     "lbl:latitude":24.820207,
     "lbl:longitude":56.045581,
@@ -119,7 +125,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1553550292,
+    "wof:lastmodified":1561066241,
     "wof:name":"Neutral Zone",
     "wof:parent_id":85632573,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes the UAE portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1640.

- Updates two "Neutral Zone" regions with some label values, though no Arabic name translations since I'm unable to verify the translation
- Updates `wof:name` and `name:*` properties in five region records that had Arabic values in the `wof:name` properties
- Adds label longnames (no placetype) to the rest of the county records - county placetypes in the UAE are not commonly used

No PIP required, can merge once approved.