### PR TITLE
WIP: Update label shortcodes

### DIFF
--- a/data/856/325/73/85632573.geojson
+++ b/data/856/325/73/85632573.geojson
@@ -20,6 +20,9 @@
     "itu:country_code":[
         "971"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "UAE"
+    ],
     "lbl:latitude":23.755128,
     "lbl:longitude":54.705518,
     "mps:latitude":23.755128,
@@ -1149,7 +1152,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1562795544,
+    "wof:lastmodified":1565634328,
     "wof:name":"United Arab Emirates",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/679/51/85667951.geojson
+++ b/data/856/679/51/85667951.geojson
@@ -24,6 +24,9 @@
     "label:eng_x_preferred_placetype":[
         "emirate"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "RK"
+    ],
     "lbl:latitude":25.694165,
     "lbl:longitude":55.977945,
     "mps:latitude":25.694165,
@@ -417,7 +420,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1562795548,
+    "wof:lastmodified":1565634329,
     "wof:name":"Ras Al Khaimah",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/55/85667955.geojson
+++ b/data/856/679/55/85667955.geojson
@@ -25,6 +25,9 @@
     "label:eng_x_preferred_placetype":[
         "emirate"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "UQ"
+    ],
     "lbl:latitude":25.529773,
     "lbl:longitude":55.718237,
     "mps:latitude":25.529773,
@@ -418,7 +421,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1562795552,
+    "wof:lastmodified":1565634329,
     "wof:name":"Umm Al Quwain",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/59/85667959.geojson
+++ b/data/856/679/59/85667959.geojson
@@ -25,6 +25,9 @@
     "label:eng_x_preferred_placetype":[
         "emirate"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "FU"
+    ],
     "lbl:latitude":25.488009,
     "lbl:longitude":56.237778,
     "mps:latitude":25.488009,
@@ -409,7 +412,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1562795545,
+    "wof:lastmodified":1565634329,
     "wof:name":"Fujairah",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/69/85667969.geojson
+++ b/data/856/679/69/85667969.geojson
@@ -25,6 +25,9 @@
     "label:eng_x_preferred_placetype":[
         "emirate"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "AJ"
+    ],
     "lbl:latitude":25.40703,
     "lbl:longitude":55.514075,
     "mps:latitude":25.40703,
@@ -415,7 +418,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1562795547,
+    "wof:lastmodified":1565634329,
     "wof:name":"Ajman",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/77/85667977.geojson
+++ b/data/856/679/77/85667977.geojson
@@ -25,6 +25,9 @@
     "label:eng_x_preferred_placetype":[
         "emirate"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "SH"
+    ],
     "lbl:latitude":25.121495,
     "lbl:longitude":55.793328,
     "mps:latitude":25.121495,
@@ -413,7 +416,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1562795555,
+    "wof:lastmodified":1565634329,
     "wof:name":"Sharjah",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/81/85667981.geojson
+++ b/data/856/679/81/85667981.geojson
@@ -25,6 +25,9 @@
     "label:eng_x_preferred_placetype":[
         "emirate"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "AZ"
+    ],
     "lbl:latitude":23.596148,
     "lbl:longitude":54.571212,
     "mps:latitude":23.596148,
@@ -452,7 +455,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1562795550,
+    "wof:lastmodified":1565634329,
     "wof:name":"Abu Dhabi",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/83/85667983.geojson
+++ b/data/856/679/83/85667983.geojson
@@ -25,6 +25,9 @@
     "label:eng_x_preferred_placetype":[
         "emirate"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "DU"
+    ],
     "lbl:latitude":24.891256,
     "lbl:longitude":55.348249,
     "mps:latitude":24.891256,
@@ -663,7 +666,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1562795554,
+    "wof:lastmodified":1565634329,
     "wof:name":"Dubai",
     "wof:parent_id":85632573,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1689.

- Adds a `label:eng_x_preferred_shortcode` property to any country, macroregion, region, or dependency record
- Removes any `wof:lang` property if `wof:lang_x_official` and `wof:lang_x_spoken` properties are present

Will not require PIP work, property edits only.