### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/137/682/640/7/1376826407.geojson
+++ b/data/137/682/640/7/1376826407.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629 \u0627\u0644\u0642\u062f\u064a\u0645\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Old Ras Al Khaimah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":1376826407,
-    "wof:lastmodified":1566581596,
-    "wof:name":"\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629 \u0627\u0644\u0642\u062f\u064a\u0645\u0629",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Old Ras Al Khaimah",
     "wof:parent_id":890455647,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/137/682/640/7/1376826407.geojson
+++ b/data/137/682/640/7/1376826407.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872961,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667951,
         102191569,
         85632573,
+        1376833605,
         890455647,
-        1376833605
+        85667951
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1376826407,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423091,
     "wof:name":"Old Ras Al Khaimah",
     "wof:parent_id":890455647,
     "wof:placetype":"neighbourhood",

--- a/data/137/682/641/1/1376826411.geojson
+++ b/data/137/682/641/1/1376826411.geojson
@@ -7,7 +7,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"55.92041,25.7134525,55.92041,25.7134525",
+    "geom:bbox":"55.92041,25.713452,55.92041,25.713452",
     "geom:latitude":25.713452,
     "geom:longitude":55.92041,
     "iso:country":"AE",
@@ -54,7 +54,7 @@
     },
     "wof:country":"AE",
     "wof:created":1459008892,
-    "wof:geomhash":"2fc939c825ae8eb4e638ec793f6bebe1",
+    "wof:geomhash":"6f9e788ce9c919410f753c23b53ca598",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1376826411,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423091,
     "wof:name":"Ras Al Khaimah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -78,9 +78,9 @@
 },
   "bbox": [
     55.92041,
-    25.7134525,
+    25.713452,
     55.92041,
-    25.7134525
+    25.713452
 ],
-  "geometry": {"coordinates":[55.92041,25.7134525],"type":"Point"}
+  "geometry": {"coordinates":[55.92041,25.713452],"type":"Point"}
 }

--- a/data/137/682/641/1/1376826411.geojson
+++ b/data/137/682/641/1/1376826411.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Ras Al Khaimah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":1376826411,
-    "wof:lastmodified":1566581596,
-    "wof:name":"\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Ras Al Khaimah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/137/682/641/5/1376826415.geojson
+++ b/data/137/682/641/5/1376826415.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1376826415,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Fallah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/137/682/641/5/1376826415.geojson
+++ b/data/137/682/641/5/1376826415.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0641\u0644\u0627\u062d"
+    ],
+    "name:eng_x_preferred":[
+        "Al Fallah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":1376826415,
-    "wof:lastmodified":1566581596,
-    "wof:name":"\u0627\u0644\u0641\u0644\u0627\u062d",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Fallah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/137/682/641/9/1376826419.geojson
+++ b/data/137/682/641/9/1376826419.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"56.0228645,25.8773725,56.0228645,25.8773725",
+    "geom:bbox":"56.022864,25.877372,56.022864,25.877372",
     "geom:latitude":25.877372,
     "geom:longitude":56.022864,
     "iso:country":"AE",
@@ -42,11 +42,11 @@
     "qs:woe_id":1940109,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667951,
         102191569,
         85632573,
+        1376833605,
         890455647,
-        1376833605
+        85667951
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"AE",
     "wof:created":1459009418,
-    "wof:geomhash":"a1740ba0e41db7fd9c88bc2b9b397a66",
+    "wof:geomhash":"ad9453c90df99fc958d0aae33d170b50",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1376826419,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Rams",
     "wof:parent_id":890455647,
     "wof:placetype":"neighbourhood",
@@ -79,10 +79,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    56.0228645,
-    25.8773725,
-    56.0228645,
-    25.8773725
+    56.022864,
+    25.877372,
+    56.022864,
+    25.877372
 ],
-  "geometry": {"coordinates":[56.0228645,25.8773725],"type":"Point"}
+  "geometry": {"coordinates":[56.022864,25.877372],"type":"Point"}
 }

--- a/data/137/682/641/9/1376826419.geojson
+++ b/data/137/682/641/9/1376826419.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0631\u0645\u0633"
+    ],
+    "name:eng_x_preferred":[
+        "Al Rams"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":1376826419,
-    "wof:lastmodified":1566581596,
-    "wof:name":"\u0627\u0644\u0631\u0645\u0633",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Rams",
     "wof:parent_id":890455647,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/137/682/642/1/1376826421.geojson
+++ b/data/137/682/642/1/1376826421.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062e\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Khan"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":1376826421,
-    "wof:lastmodified":1566581595,
-    "wof:name":"\u062e\u0627\u0646",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Khan",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/137/682/642/1/1376826421.geojson
+++ b/data/137/682/642/1/1376826421.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":1940075,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667977,
         102191569,
         85632573,
+        421171391,
         421168683,
-        421171391
+        85667977
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1376826421,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423090,
     "wof:name":"Khan",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",

--- a/data/137/682/642/3/1376826423.geojson
+++ b/data/137/682/642/3/1376826423.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u0641\u0627\u064a\u0636\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Ain Al Faydah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":1376826423,
-    "wof:lastmodified":1566581595,
-    "wof:name":"\u0639\u064a\u0646 \u0627\u0644\u0641\u0627\u064a\u0636\u0629",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Ain Al Faydah",
     "wof:parent_id":421168687,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/137/682/642/3/1376826423.geojson
+++ b/data/137/682/642/3/1376826423.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":1940127,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667981,
         102191569,
         85632573,
+        421200931,
         421168687,
-        421200931
+        85667981
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1376826423,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423083,
     "wof:name":"Ain Al Faydah",
     "wof:parent_id":421168687,
     "wof:placetype":"neighbourhood",

--- a/data/137/682/642/7/1376826427.geojson
+++ b/data/137/682/642/7/1376826427.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0639\u0645\u0648\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Mamurah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":1376826427,
-    "wof:lastmodified":1566581595,
-    "wof:name":"\u0627\u0644\u0645\u0639\u0645\u0648\u0631\u0629",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Mamurah",
     "wof:parent_id":890455647,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/137/682/642/7/1376826427.geojson
+++ b/data/137/682/642/7/1376826427.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872993,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667951,
         102191569,
         85632573,
+        1376833605,
         890455647,
-        1376833605
+        85667951
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1376826427,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Mamurah",
     "wof:parent_id":890455647,
     "wof:placetype":"neighbourhood",

--- a/data/137/682/642/9/1376826429.geojson
+++ b/data/137/682/642/9/1376826429.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":1940040,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667983,
         102191569,
         85632573,
+        1376833603,
         421174961,
-        1376833603
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1376826429,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423082,
     "wof:name":"Abu Hail",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/137/682/642/9/1376826429.geojson
+++ b/data/137/682/642/9/1376826429.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0628\u0648 \u0647\u064a\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Abu Hail"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":1376826429,
-    "wof:lastmodified":1566581595,
-    "wof:name":"\u0627\u0628\u0648 \u0647\u064a\u0644",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Abu Hail",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/137/682/643/1/1376826431.geojson
+++ b/data/137/682/643/1/1376826431.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0634\u0647\u0627\u0645\u0629 \u0627\u0644\u062c\u062f\u064a\u062f\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Shahama Al Jadeeda"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -59,8 +65,8 @@
         }
     ],
     "wof:id":1376826431,
-    "wof:lastmodified":1566581594,
-    "wof:name":"\u0627\u0644\u0634\u0647\u0627\u0645\u0629 \u0627\u0644\u062c\u062f\u064a\u062f\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Shahama Al Jadeeda",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/137/682/643/1/1376826431.geojson
+++ b/data/137/682/643/1/1376826431.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1376826431,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Shahama Al Jadeeda",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/137/682/643/3/1376826433.geojson
+++ b/data/137/682/643/3/1376826433.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872474,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667981,
         102191569,
         85632573,
+        421172075,
         421179641,
-        421172075
+        85667981
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1376826433,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Bahyah",
     "wof:parent_id":421179641,
     "wof:placetype":"neighbourhood",

--- a/data/137/682/643/3/1376826433.geojson
+++ b/data/137/682/643/3/1376826433.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0628\u0627\u0647\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Bahyah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":1376826433,
-    "wof:lastmodified":1566581594,
-    "wof:name":"\u0627\u0644\u0628\u0627\u0647\u064a\u0629",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Al Bahyah",
     "wof:parent_id":421179641,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/168/593/421168593.geojson
+++ b/data/421/168/593/421168593.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629 \u0627\u0644\u0642\u062f\u064a\u0645\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Old Ras Al Khaimah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":421168593,
-    "wof:lastmodified":1548974137,
-    "wof:name":"\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629 \u0627\u0644\u0642\u062f\u064a\u0645\u0629",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Old Ras Al Khaimah",
     "wof:parent_id":1376833605,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/168/593/421168593.geojson
+++ b/data/421/168/593/421168593.geojson
@@ -42,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667951,
-        1376833605
+        1376833605,
+        85667951
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":421168593,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423091,
     "wof:name":"Old Ras Al Khaimah",
     "wof:parent_id":1376833605,
     "wof:placetype":"locality",

--- a/data/421/169/195/421169195.geojson
+++ b/data/421/169/195/421169195.geojson
@@ -19,6 +19,12 @@
     "name:ara_x_preferred":[
         "\u0639\u0648\u062f \u0645\u064a\u062b\u0627\u0621"
     ],
+    "name:ara_x_variant":[
+        "\u0639\u0648\u062f \u0645\u064a\u062b\u0627\u0621"
+    ],
+    "name:eng_x_preferred":[
+        "Oud Metha"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":6691115,
@@ -65,8 +71,8 @@
         }
     ],
     "wof:id":421169195,
-    "wof:lastmodified":1566581599,
-    "wof:name":"\u0639\u0648\u062f \u0645\u064a\u062b\u0627\u0621",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Oud Metha",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/169/195/421169195.geojson
+++ b/data/421/169/195/421169195.geojson
@@ -19,9 +19,6 @@
     "name:ara_x_preferred":[
         "\u0639\u0648\u062f \u0645\u064a\u062b\u0627\u0621"
     ],
-    "name:ara_x_variant":[
-        "\u0639\u0648\u062f \u0645\u064a\u062b\u0627\u0621"
-    ],
     "name:eng_x_preferred":[
         "Oud Metha"
     ],
@@ -45,11 +42,11 @@
     "qs:woe_id":55872621,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667983,
         102191569,
         85632573,
+        1376833603,
         421174961,
-        1376833603
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -71,7 +68,7 @@
         }
     ],
     "wof:id":421169195,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423091,
     "wof:name":"Oud Metha",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/169/197/421169197.geojson
+++ b/data/421/169/197/421169197.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0639\u0648\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Al Awan"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":6691212,
@@ -62,8 +68,8 @@
         }
     ],
     "wof:id":421169197,
-    "wof:lastmodified":1566581600,
-    "wof:name":"\u0627\u0644\u0639\u0648\u0627\u0646",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Awan",
     "wof:parent_id":1126024975,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/169/197/421169197.geojson
+++ b/data/421/169/197/421169197.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872421,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667969,
         102191569,
         85632573,
+        1376833607,
         1126024975,
-        1376833607
+        85667969
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":421169197,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Awan",
     "wof:parent_id":1126024975,
     "wof:placetype":"neighbourhood",

--- a/data/421/170/549/421170549.geojson
+++ b/data/421/170/549/421170549.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062f\u0628\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Dubai"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421170549,
-    "wof:lastmodified":1548974147,
-    "wof:name":"\u062f\u0628\u064a",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Dubai",
     "wof:parent_id":-1,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/170/549/421170549.geojson
+++ b/data/421/170/549/421170549.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421170549,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423088,
     "wof:name":"Dubai",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/170/935/421170935.geojson
+++ b/data/421/170/935/421170935.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872416,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667983,
         102191569,
         85632573,
+        1376833603,
         421174961,
-        1376833603
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421170935,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Daghia",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/170/935/421170935.geojson
+++ b/data/421/170/935/421170935.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062f\u063a\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Daghia"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421170935,
-    "wof:lastmodified":1566581604,
-    "wof:name":"\u0627\u0644\u062f\u063a\u064a\u0629",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Daghia",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/170/937/421170937.geojson
+++ b/data/421/170/937/421170937.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667977,
-        1376826393
+        1376826393,
+        85667977
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421170937,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Malayha",
     "wof:parent_id":1376826393,
     "wof:placetype":"locality",

--- a/data/421/170/937/421170937.geojson
+++ b/data/421/170/937/421170937.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0644\u0627\u064a\u062d\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Malayha"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421170937,
-    "wof:lastmodified":1566581604,
-    "wof:name":"\u0627\u0644\u0645\u0644\u0627\u064a\u062d\u0629",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Malayha",
     "wof:parent_id":1376826393,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/171/387/421171387.geojson
+++ b/data/421/171/387/421171387.geojson
@@ -7,7 +7,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"55.92041,25.7134525,55.92041,25.7134525",
+    "geom:bbox":"55.92041,25.713452,55.92041,25.713452",
     "geom:latitude":25.713452,
     "geom:longitude":55.92041,
     "iso:country":"AE",
@@ -51,7 +51,7 @@
     },
     "wof:country":"AE",
     "wof:created":1459008892,
-    "wof:geomhash":"2fc939c825ae8eb4e638ec793f6bebe1",
+    "wof:geomhash":"6f9e788ce9c919410f753c23b53ca598",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":421171387,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423091,
     "wof:name":"Ras Al Khaimah",
     "wof:parent_id":85667951,
     "wof:placetype":"county",
@@ -74,9 +74,9 @@
 },
   "bbox": [
     55.92041,
-    25.7134525,
+    25.713452,
     55.92041,
-    25.7134525
+    25.713452
 ],
-  "geometry": {"coordinates":[55.92041,25.7134525],"type":"Point"}
+  "geometry": {"coordinates":[55.92041,25.713452],"type":"Point"}
 }

--- a/data/421/171/387/421171387.geojson
+++ b/data/421/171/387/421171387.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Ras Al Khaimah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -55,8 +61,8 @@
         }
     ],
     "wof:id":421171387,
-    "wof:lastmodified":1548974148,
-    "wof:name":"\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Ras Al Khaimah",
     "wof:parent_id":85667951,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/171/393/421171393.geojson
+++ b/data/421/171/393/421171393.geojson
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":421171393,
-    "wof:lastmodified":1601068387,
+    "wof:lastmodified":1601423094,
     "wof:name":"Umm Al Quwain",
     "wof:parent_id":85667955,
     "wof:placetype":"county",

--- a/data/421/171/393/421171393.geojson
+++ b/data/421/171/393/421171393.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0623\u0645 \u0627\u0644\u0642\u064a\u0648\u064a\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Umm Al Quwain"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -55,8 +61,8 @@
         }
     ],
     "wof:id":421171393,
-    "wof:lastmodified":1548974152,
-    "wof:name":"\u0623\u0645 \u0627\u0644\u0642\u064a\u0648\u064a\u0646",
+    "wof:lastmodified":1601068387,
+    "wof:name":"Umm Al Quwain",
     "wof:parent_id":85667955,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/172/133/421172133.geojson
+++ b/data/421/172/133/421172133.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Ras Al Khaimah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":421172133,
-    "wof:lastmodified":1548974159,
-    "wof:name":"\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Ras Al Khaimah",
     "wof:parent_id":1376833605,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/172/133/421172133.geojson
+++ b/data/421/172/133/421172133.geojson
@@ -42,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667951,
-        1376833605
+        1376833605,
+        85667951
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":421172133,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423091,
     "wof:name":"Ras Al Khaimah",
     "wof:parent_id":1376833605,
     "wof:placetype":"locality",

--- a/data/421/173/537/421173537.geojson
+++ b/data/421/173/537/421173537.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55873078,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667977,
         102191569,
         85632573,
+        421171391,
         421168683,
-        421171391
+        85667977
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421173537,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Mrayjeh",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",

--- a/data/421/173/537/421173537.geojson
+++ b/data/421/173/537/421173537.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0631\u064a\u062c\u0647"
+    ],
+    "name:eng_x_preferred":[
+        "Al Mrayjeh"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421173537,
-    "wof:lastmodified":1566581601,
-    "wof:name":"\u0627\u0644\u0645\u0631\u064a\u062c\u0647",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Mrayjeh",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/175/599/421175599.geojson
+++ b/data/421/175/599/421175599.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872871,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667983,
         102191569,
         85632573,
+        1376833603,
         421174961,
-        1376833603
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421175599,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Morouj 1",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/175/599/421175599.geojson
+++ b/data/421/175/599/421175599.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0631\u0648\u062c 1"
+    ],
+    "name:eng_x_preferred":[
+        "Al Morouj 1"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421175599,
-    "wof:lastmodified":1566581602,
-    "wof:name":"\u0627\u0644\u0645\u0631\u0648\u062c 1",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Morouj 1",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/175/777/421175777.geojson
+++ b/data/421/175/777/421175777.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667955,
-        1376833609
+        1376833609,
+        85667955
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421175777,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423094,
     "wof:name":"Umm Al Thuoob Industrial Area",
     "wof:parent_id":1376833609,
     "wof:placetype":"locality",

--- a/data/421/175/777/421175777.geojson
+++ b/data/421/175/777/421175777.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0646\u0637\u0642\u0629 \u0627\u0645 \u0627\u0644\u062b\u0639\u0648\u0628 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Umm Al Thuoob Industrial Area"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421175777,
-    "wof:lastmodified":1566581602,
-    "wof:name":"\u0645\u0646\u0637\u0642\u0629 \u0627\u0645 \u0627\u0644\u062b\u0639\u0648\u0628 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Umm Al Thuoob Industrial Area",
     "wof:parent_id":1376833609,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/178/001/421178001.geojson
+++ b/data/421/178/001/421178001.geojson
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":421178001,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Fallah",
     "wof:parent_id":85667981,
     "wof:placetype":"county",

--- a/data/421/178/001/421178001.geojson
+++ b/data/421/178/001/421178001.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0641\u0644\u0627\u062d"
+    ],
+    "name:eng_x_preferred":[
+        "Al Fallah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -55,8 +61,8 @@
         }
     ],
     "wof:id":421178001,
-    "wof:lastmodified":1548974164,
-    "wof:name":"\u0627\u0644\u0641\u0644\u0627\u062d",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Fallah",
     "wof:parent_id":85667981,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/178/047/421178047.geojson
+++ b/data/421/178/047/421178047.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667951,
-        1376833605
+        1376833605,
+        85667951
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421178047,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sha'am",
     "wof:parent_id":1376833605,
     "wof:placetype":"locality",

--- a/data/421/178/047/421178047.geojson
+++ b/data/421/178/047/421178047.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0634\u0639\u0645"
+    ],
+    "name:eng_x_preferred":[
+        "Sha'am"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421178047,
-    "wof:lastmodified":1566581605,
-    "wof:name":"\u0634\u0639\u0645",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sha'am",
     "wof:parent_id":1376833605,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/180/109/421180109.geojson
+++ b/data/421/180/109/421180109.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0641\u0627\u064a\u062d\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Fayha"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":6691189,
@@ -62,8 +68,8 @@
         }
     ],
     "wof:id":421180109,
-    "wof:lastmodified":1566581600,
-    "wof:name":"\u0627\u0644\u0641\u0627\u064a\u062d\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Fayha",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/180/109/421180109.geojson
+++ b/data/421/180/109/421180109.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872546,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667977,
         102191569,
         85632573,
+        421171391,
         421168683,
-        421171391
+        85667977
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":421180109,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Fayha",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",

--- a/data/421/183/219/421183219.geojson
+++ b/data/421/183/219/421183219.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872526,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667969,
         102191569,
         85632573,
+        1376833607,
         1126024975,
-        1376833607
+        85667969
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":421183219,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Nakheel",
     "wof:parent_id":1126024975,
     "wof:placetype":"neighbourhood",

--- a/data/421/183/219/421183219.geojson
+++ b/data/421/183/219/421183219.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0646\u062e\u064a\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Al Nakheel"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":6691211,
@@ -62,8 +68,8 @@
         }
     ],
     "wof:id":421183219,
-    "wof:lastmodified":1566581604,
-    "wof:name":"\u0627\u0644\u0646\u062e\u064a\u0644",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Nakheel",
     "wof:parent_id":1126024975,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/183/945/421183945.geojson
+++ b/data/421/183/945/421183945.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0642\u0648\u0632 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629 3"
+    ],
+    "name:eng_x_preferred":[
+        "Al Quoz Industrail Area 3"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421183945,
-    "wof:lastmodified":1566581604,
-    "wof:name":"\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0642\u0648\u0632 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629 3",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Al Quoz Industrail Area 3",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/183/945/421183945.geojson
+++ b/data/421/183/945/421183945.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"55.2194655,25.1401665,55.2194655,25.1401665",
+    "geom:bbox":"55.219465,25.140166,55.219465,25.140166",
     "geom:latitude":25.140166,
     "geom:longitude":55.219465,
     "iso:country":"AE",
@@ -42,11 +42,11 @@
     "qs:woe_id":55872610,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667983,
         102191569,
         85632573,
+        1376833603,
         421174961,
-        1376833603
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"AE",
     "wof:created":1459009395,
-    "wof:geomhash":"7be76a5f9f86a471cf9c59aff543f5c8",
+    "wof:geomhash":"3af3d2335168085f5d990d9e2cab7896",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421183945,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Quoz Industrail Area 3",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",
@@ -77,10 +77,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    55.2194655,
-    25.1401665,
-    55.2194655,
-    25.1401665
+    55.219465,
+    25.140166,
+    55.219465,
+    25.140166
 ],
-  "geometry": {"coordinates":[55.2194655,25.1401665],"type":"Point"}
+  "geometry": {"coordinates":[55.219465,25.140166],"type":"Point"}
 }

--- a/data/421/183/947/421183947.geojson
+++ b/data/421/183/947/421183947.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0643\u0648\u0631\u0646\u064a\u0634 \u0627\u0644\u0628\u062d\u064a\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Lake Trail"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421183947,
-    "wof:lastmodified":1566581604,
-    "wof:name":"\u0643\u0648\u0631\u0646\u064a\u0634 \u0627\u0644\u0628\u062d\u064a\u0631\u0629",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Lake Trail",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/183/947/421183947.geojson
+++ b/data/421/183/947/421183947.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872944,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667977,
         102191569,
         85632573,
+        421171391,
         421168683,
-        421171391
+        85667977
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421183947,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423090,
     "wof:name":"Lake Trail",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",

--- a/data/421/184/217/421184217.geojson
+++ b/data/421/184/217/421184217.geojson
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":421184217,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Shahama",
     "wof:parent_id":85667981,
     "wof:placetype":"county",

--- a/data/421/184/217/421184217.geojson
+++ b/data/421/184/217/421184217.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0634\u0647\u0627\u0645\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Shahama"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -55,8 +61,8 @@
         }
     ],
     "wof:id":421184217,
-    "wof:lastmodified":1548974168,
-    "wof:name":"\u0627\u0644\u0634\u0647\u0627\u0645\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Shahama",
     "wof:parent_id":85667981,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/184/663/421184663.geojson
+++ b/data/421/184/663/421184663.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0631\u0645\u0633"
+    ],
+    "name:eng_x_preferred":[
+        "Al Rams"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":421184663,
-    "wof:lastmodified":1548974170,
-    "wof:name":"\u0627\u0644\u0631\u0645\u0633",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Rams",
     "wof:parent_id":1376833605,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/184/663/421184663.geojson
+++ b/data/421/184/663/421184663.geojson
@@ -7,7 +7,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"56.0228645,25.8773725,56.0228645,25.8773725",
+    "geom:bbox":"56.022864,25.877372,56.022864,25.877372",
     "geom:latitude":25.877372,
     "geom:longitude":56.022864,
     "iso:country":"AE",
@@ -42,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667951,
-        1376833605
+        1376833605,
+        85667951
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -52,7 +52,7 @@
     },
     "wof:country":"AE",
     "wof:created":1459009418,
-    "wof:geomhash":"a1740ba0e41db7fd9c88bc2b9b397a66",
+    "wof:geomhash":"ad9453c90df99fc958d0aae33d170b50",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":421184663,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Rams",
     "wof:parent_id":1376833605,
     "wof:placetype":"locality",
@@ -75,10 +75,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    56.0228645,
-    25.8773725,
-    56.0228645,
-    25.8773725
+    56.022864,
+    25.877372,
+    56.022864,
+    25.877372
 ],
-  "geometry": {"coordinates":[56.0228645,25.8773725],"type":"Point"}
+  "geometry": {"coordinates":[56.022864,25.877372],"type":"Point"}
 }

--- a/data/421/184/697/421184697.geojson
+++ b/data/421/184/697/421184697.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872554,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667983,
         102191569,
         85632573,
+        1376833603,
         421174961,
-        1376833603
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421184697,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423090,
     "wof:name":"Jumeirah 3",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/184/697/421184697.geojson
+++ b/data/421/184/697/421184697.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062c\u0645\u064a\u0631\u0627 3"
+    ],
+    "name:eng_x_preferred":[
+        "Jumeirah 3"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421184697,
-    "wof:lastmodified":1566581604,
-    "wof:name":"\u062c\u0645\u064a\u0631\u0627 3",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Jumeirah 3",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/185/041/421185041.geojson
+++ b/data/421/185/041/421185041.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0631\u0641\u0627\u062d"
+    ],
+    "name:eng_x_preferred":[
+        "Al Rifaah"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":6691209,
@@ -62,8 +68,8 @@
         }
     ],
     "wof:id":421185041,
-    "wof:lastmodified":1566581605,
-    "wof:name":"\u0627\u0644\u0631\u0641\u0627\u062d",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Rifaah",
     "wof:parent_id":1126024975,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/185/041/421185041.geojson
+++ b/data/421/185/041/421185041.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55873053,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667969,
         102191569,
         85632573,
+        1376833607,
         1126024975,
-        1376833607
+        85667969
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":421185041,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Rifaah",
     "wof:parent_id":1126024975,
     "wof:placetype":"neighbourhood",

--- a/data/421/185/279/421185279.geojson
+++ b/data/421/185/279/421185279.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0633\u0648\u0642 \u0627\u0644\u0643\u0628\u064a\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Al souq Al Kabeer"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421185279,
-    "wof:lastmodified":1566581605,
-    "wof:name":"\u0627\u0644\u0633\u0648\u0642 \u0627\u0644\u0643\u0628\u064a\u0631",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al souq Al Kabeer",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/185/279/421185279.geojson
+++ b/data/421/185/279/421185279.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872943,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667983,
         102191569,
         85632573,
+        1376833603,
         421174961,
-        1376833603
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421185279,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al souq Al Kabeer",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/185/523/421185523.geojson
+++ b/data/421/185/523/421185523.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872451,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667969,
         102191569,
         85632573,
+        1376833607,
         1126024975,
-        1376833607
+        85667969
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":421185523,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Bustan",
     "wof:parent_id":1126024975,
     "wof:placetype":"neighbourhood",

--- a/data/421/185/523/421185523.geojson
+++ b/data/421/185/523/421185523.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0628\u0633\u062a\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Al Bustan"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":6691213,
@@ -62,8 +68,8 @@
         }
     ],
     "wof:id":421185523,
-    "wof:lastmodified":1566581605,
-    "wof:name":"\u0627\u0644\u0628\u0633\u062a\u0627\u0646",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Bustan",
     "wof:parent_id":1126024975,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/185/629/421185629.geojson
+++ b/data/421/185/629/421185629.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062d\u062a\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Hatta"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185629,
-    "wof:lastmodified":1566581605,
-    "wof:name":"\u062d\u062a\u0627",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Hatta",
     "wof:parent_id":1376833603,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/185/629/421185629.geojson
+++ b/data/421/185/629/421185629.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667983,
-        1376833603
+        1376833603,
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185629,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423089,
     "wof:name":"Hatta",
     "wof:parent_id":1376833603,
     "wof:placetype":"locality",

--- a/data/421/185/633/421185633.geojson
+++ b/data/421/185/633/421185633.geojson
@@ -59,7 +59,7 @@
         }
     ],
     "wof:id":421185633,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423087,
     "wof:name":"Bakha",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/185/633/421185633.geojson
+++ b/data/421/185/633/421185633.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u062e\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Bakha"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -53,8 +59,8 @@
         }
     ],
     "wof:id":421185633,
-    "wof:lastmodified":1548974171,
-    "wof:name":"\u0628\u062e\u0627",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Bakha",
     "wof:parent_id":-1,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/186/451/421186451.geojson
+++ b/data/421/186/451/421186451.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062d\u062a\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Hatta"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -53,8 +59,8 @@
         }
     ],
     "wof:id":421186451,
-    "wof:lastmodified":1548974173,
-    "wof:name":"\u062d\u062a\u0627",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Hatta",
     "wof:parent_id":-1,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/186/451/421186451.geojson
+++ b/data/421/186/451/421186451.geojson
@@ -7,7 +7,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"56.19996,24.8201195,56.19996,24.8201195",
+    "geom:bbox":"56.19996,24.82012,56.19996,24.82012",
     "geom:latitude":24.82012,
     "geom:longitude":56.19996,
     "iso:country":"AE",
@@ -49,7 +49,7 @@
     },
     "wof:country":"AE",
     "wof:created":1459009481,
-    "wof:geomhash":"c53e56d2eff92a1c06678a69df30c1dc",
+    "wof:geomhash":"80d034dddd9012f533f976b7acadf9d9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -59,7 +59,7 @@
         }
     ],
     "wof:id":421186451,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423089,
     "wof:name":"Hatta",
     "wof:parent_id":-1,
     "wof:placetype":"county",
@@ -70,9 +70,9 @@
 },
   "bbox": [
     56.19996,
-    24.8201195,
+    24.82012,
     56.19996,
-    24.8201195
+    24.82012
 ],
-  "geometry": {"coordinates":[56.19996,24.8201195],"type":"Point"}
+  "geometry": {"coordinates":[56.19996,24.82012],"type":"Point"}
 }

--- a/data/421/188/275/421188275.geojson
+++ b/data/421/188/275/421188275.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0632\u064a\u0631\u0639"
+    ],
+    "name:eng_x_preferred":[
+        "Muzeera"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421188275,
-    "wof:lastmodified":1566581601,
-    "wof:name":"\u0645\u0632\u064a\u0631\u0639",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Muzeera",
     "wof:parent_id":1376826403,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/188/275/421188275.geojson
+++ b/data/421/188/275/421188275.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667981,
-        1376826403
+        1376826403,
+        85667981
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421188275,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423091,
     "wof:name":"Muzeera",
     "wof:parent_id":1376826403,
     "wof:placetype":"locality",

--- a/data/421/188/801/421188801.geojson
+++ b/data/421/188/801/421188801.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0648 \u062f\u0627\u0646\u0642"
+    ],
+    "name:eng_x_preferred":[
+        "Bu Daniq"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":6691119,
@@ -62,8 +68,8 @@
         }
     ],
     "wof:id":421188801,
-    "wof:lastmodified":1566581601,
-    "wof:name":"\u0628\u0648 \u062f\u0627\u0646\u0642",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Bu Daniq",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/188/801/421188801.geojson
+++ b/data/421/188/801/421188801.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872514,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667977,
         102191569,
         85632573,
+        421171391,
         421168683,
-        421171391
+        85667977
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":421188801,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Bu Daniq",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",

--- a/data/421/188/807/421188807.geojson
+++ b/data/421/188/807/421188807.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872767,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667977,
         102191569,
         85632573,
+        421171391,
         421168683,
-        421171391
+        85667977
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":421188807,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Yarmouk",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",

--- a/data/421/188/807/421188807.geojson
+++ b/data/421/188/807/421188807.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u064a\u0631\u0645\u0648\u0643"
+    ],
+    "name:eng_x_preferred":[
+        "Al Yarmouk"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":6691122,
@@ -62,8 +68,8 @@
         }
     ],
     "wof:id":421188807,
-    "wof:lastmodified":1566581601,
-    "wof:name":"\u0627\u0644\u064a\u0631\u0645\u0648\u0643",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Yarmouk",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/188/809/421188809.geojson
+++ b/data/421/188/809/421188809.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872902,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667977,
         102191569,
         85632573,
+        421171391,
         421168683,
-        421171391
+        85667977
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":421188809,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Qouz",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",

--- a/data/421/188/809/421188809.geojson
+++ b/data/421/188/809/421188809.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0642\u0648\u0632"
+    ],
+    "name:eng_x_preferred":[
+        "Al Qouz"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":6691200,
@@ -62,8 +68,8 @@
         }
     ],
     "wof:id":421188809,
-    "wof:lastmodified":1566581601,
-    "wof:name":"\u0627\u0644\u0642\u0648\u0632",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Qouz",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/188/811/421188811.geojson
+++ b/data/421/188/811/421188811.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u063a\u0648\u064a\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Al Ghuwair"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":6691135,
@@ -62,8 +68,8 @@
         }
     ],
     "wof:id":421188811,
-    "wof:lastmodified":1566581601,
-    "wof:name":"\u0627\u0644\u063a\u0648\u064a\u0631",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Ghuwair",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/188/811/421188811.geojson
+++ b/data/421/188/811/421188811.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872940,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667977,
         102191569,
         85632573,
+        421171391,
         421168683,
-        421171391
+        85667977
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":421188811,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Ghuwair",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",

--- a/data/421/189/273/421189273.geojson
+++ b/data/421/189/273/421189273.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0637\u0648\u064a \u0632\u0628\u064a\u0631 \u062d\u0645\u0631\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Tawi Zubair Hamriyah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421189273,
-    "wof:lastmodified":1566581601,
-    "wof:name":"\u0637\u0648\u064a \u0632\u0628\u064a\u0631 \u062d\u0645\u0631\u064a\u0629",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Tawi Zubair Hamriyah",
     "wof:parent_id":1376826391,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/189/273/421189273.geojson
+++ b/data/421/189/273/421189273.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667977,
-        1376826391
+        1376826391,
+        85667977
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421189273,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tawi Zubair Hamriyah",
     "wof:parent_id":1376826391,
     "wof:placetype":"locality",

--- a/data/421/190/333/421190333.geojson
+++ b/data/421/190/333/421190333.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062e\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Khan"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":421190333,
-    "wof:lastmodified":1548974175,
-    "wof:name":"\u062e\u0627\u0646",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Khan",
     "wof:parent_id":421171391,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/190/333/421190333.geojson
+++ b/data/421/190/333/421190333.geojson
@@ -42,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667977,
-        421171391
+        421171391,
+        85667977
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":421190333,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423090,
     "wof:name":"Khan",
     "wof:parent_id":421171391,
     "wof:placetype":"locality",

--- a/data/421/190/335/421190335.geojson
+++ b/data/421/190/335/421190335.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u0641\u0627\u064a\u0636\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Ain Al Faydah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -55,8 +61,8 @@
         }
     ],
     "wof:id":421190335,
-    "wof:lastmodified":1548974176,
-    "wof:name":"\u0639\u064a\u0646 \u0627\u0644\u0641\u0627\u064a\u0636\u0629",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Ain Al Faydah",
     "wof:parent_id":85667981,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/190/335/421190335.geojson
+++ b/data/421/190/335/421190335.geojson
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":421190335,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423083,
     "wof:name":"Ain Al Faydah",
     "wof:parent_id":85667981,
     "wof:placetype":"locality",

--- a/data/421/190/351/421190351.geojson
+++ b/data/421/190/351/421190351.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0636\u062f\u0646\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Dhadna"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190351,
-    "wof:lastmodified":1566581603,
-    "wof:name":"\u0636\u062f\u0646\u0629",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Dhadna",
     "wof:parent_id":1376833611,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/190/351/421190351.geojson
+++ b/data/421/190/351/421190351.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667959,
-        1376833611
+        1376833611,
+        85667959
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190351,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423088,
     "wof:name":"Dhadna",
     "wof:parent_id":1376833611,
     "wof:placetype":"locality",

--- a/data/421/191/767/421191767.geojson
+++ b/data/421/191/767/421191767.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"54.9193665,24.892763,54.9193665,24.892763",
+    "geom:bbox":"54.919367,24.892763,54.919367,24.892763",
     "geom:latitude":24.892763,
     "geom:longitude":54.919367,
     "iso:country":"AE",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667981,
-        421172075
+        421172075,
+        85667981
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"AE",
     "wof:created":1459009709,
-    "wof:geomhash":"4a7595a88e0e8d17abe2e66fe6d0cee2",
+    "wof:geomhash":"01d8c72679d1cf24b34d44bcfc426086",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191767,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sieh Shuaib",
     "wof:parent_id":421172075,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    54.9193665,
+    54.919367,
     24.892763,
-    54.9193665,
+    54.919367,
     24.892763
 ],
-  "geometry": {"coordinates":[54.9193665,24.892763],"type":"Point"}
+  "geometry": {"coordinates":[54.919367,24.892763],"type":"Point"}
 }

--- a/data/421/191/767/421191767.geojson
+++ b/data/421/191/767/421191767.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u064a\u062d \u0634\u0639\u064a\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Sieh Shuaib"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191767,
-    "wof:lastmodified":1566581603,
-    "wof:name":"\u0633\u064a\u062d \u0634\u0639\u064a\u0628",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sieh Shuaib",
     "wof:parent_id":421172075,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/192/895/421192895.geojson
+++ b/data/421/192/895/421192895.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872725,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667977,
         102191569,
         85632573,
+        421171391,
         421168683,
-        421171391
+        85667977
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":421192895,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Murqab",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",

--- a/data/421/192/895/421192895.geojson
+++ b/data/421/192/895/421192895.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0631\u0642\u0627\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Al Murqab"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":6691208,
@@ -62,8 +68,8 @@
         }
     ],
     "wof:id":421192895,
-    "wof:lastmodified":1566581599,
-    "wof:name":"\u0627\u0644\u0645\u0631\u0642\u0627\u0628",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Murqab",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/193/605/421193605.geojson
+++ b/data/421/193/605/421193605.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0642\u0631\u0647\u0648\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Al Garhoud"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421193605,
-    "wof:lastmodified":1566581599,
-    "wof:name":"\u0627\u0644\u0642\u0631\u0647\u0648\u062f",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Garhoud",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/193/605/421193605.geojson
+++ b/data/421/193/605/421193605.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"55.3426185,25.241969,55.3426185,25.241969",
+    "geom:bbox":"55.342619,25.241969,55.342619,25.241969",
     "geom:latitude":25.241969,
     "geom:longitude":55.342619,
     "iso:country":"AE",
@@ -42,11 +42,11 @@
     "qs:woe_id":22724549,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667983,
         102191569,
         85632573,
+        1376833603,
         421174961,
-        1376833603
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"AE",
     "wof:created":1459009777,
-    "wof:geomhash":"c715b7d870b3f885ba14e5243d266e19",
+    "wof:geomhash":"4d4ec3a11f30da5692bab152e96b0ee2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421193605,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Garhoud",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",
@@ -77,10 +77,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    55.3426185,
+    55.342619,
     25.241969,
-    55.3426185,
+    55.342619,
     25.241969
 ],
-  "geometry": {"coordinates":[55.3426185,25.241969],"type":"Point"}
+  "geometry": {"coordinates":[55.342619,25.241969],"type":"Point"}
 }

--- a/data/421/195/935/421195935.geojson
+++ b/data/421/195/935/421195935.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0641\u062c\u064a\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Fujaira"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -55,8 +61,8 @@
         }
     ],
     "wof:id":421195935,
-    "wof:lastmodified":1548974178,
-    "wof:name":"\u0627\u0644\u0641\u062c\u064a\u0631\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Fujaira",
     "wof:parent_id":85667959,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/195/935/421195935.geojson
+++ b/data/421/195/935/421195935.geojson
@@ -7,7 +7,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"56.2911985,25.157715,56.2911985,25.157715",
+    "geom:bbox":"56.291199,25.157715,56.291199,25.157715",
     "geom:latitude":25.157715,
     "geom:longitude":56.291199,
     "iso:country":"AE",
@@ -51,7 +51,7 @@
     },
     "wof:country":"AE",
     "wof:created":1459009864,
-    "wof:geomhash":"65da90e875698ccdacf01d3376b0bc99",
+    "wof:geomhash":"1bcb33e9785e687b6802c74e6f155fda",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":421195935,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Fujaira",
     "wof:parent_id":85667959,
     "wof:placetype":"county",
@@ -71,10 +71,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    56.2911985,
+    56.291199,
     25.157715,
-    56.2911985,
+    56.291199,
     25.157715
 ],
-  "geometry": {"coordinates":[56.2911985,25.157715],"type":"Point"}
+  "geometry": {"coordinates":[56.291199,25.157715],"type":"Point"}
 }

--- a/data/421/197/069/421197069.geojson
+++ b/data/421/197/069/421197069.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0639\u0645\u0648\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Mamurah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":421197069,
-    "wof:lastmodified":1548974179,
-    "wof:name":"\u0627\u0644\u0645\u0639\u0645\u0648\u0631\u0629",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Mamurah",
     "wof:parent_id":1376833605,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/197/069/421197069.geojson
+++ b/data/421/197/069/421197069.geojson
@@ -42,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667951,
-        1376833605
+        1376833605,
+        85667951
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":421197069,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Mamurah",
     "wof:parent_id":1376833605,
     "wof:placetype":"locality",

--- a/data/421/198/221/421198221.geojson
+++ b/data/421/198/221/421198221.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u0645\u0646\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Semnan"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":6691125,
@@ -62,8 +68,8 @@
         }
     ],
     "wof:id":421198221,
-    "wof:lastmodified":1566581602,
-    "wof:name":"\u0633\u0645\u0646\u0627\u0646",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Semnan",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/198/221/421198221.geojson
+++ b/data/421/198/221/421198221.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872903,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667977,
         102191569,
         85632573,
+        421171391,
         421168683,
-        421171391
+        85667977
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":421198221,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Semnan",
     "wof:parent_id":421168683,
     "wof:placetype":"neighbourhood",

--- a/data/421/198/239/421198239.geojson
+++ b/data/421/198/239/421198239.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872587,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667969,
         102191569,
         85632573,
+        1376833607,
         1126024975,
-        1376833607
+        85667969
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":421198239,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Bateen",
     "wof:parent_id":1126024975,
     "wof:placetype":"neighbourhood",

--- a/data/421/198/239/421198239.geojson
+++ b/data/421/198/239/421198239.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0628\u0637\u064a\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Al Bateen"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":6691214,
@@ -62,8 +68,8 @@
         }
     ],
     "wof:id":421198239,
-    "wof:lastmodified":1566581602,
-    "wof:name":"\u0627\u0644\u0628\u0637\u064a\u0646",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Bateen",
     "wof:parent_id":1126024975,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/200/925/421200925.geojson
+++ b/data/421/200/925/421200925.geojson
@@ -42,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667983,
-        1376833603
+        1376833603,
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":421200925,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423083,
     "wof:name":"Abu Hail",
     "wof:parent_id":1376833603,
     "wof:placetype":"locality",

--- a/data/421/200/925/421200925.geojson
+++ b/data/421/200/925/421200925.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0628\u0648 \u0647\u064a\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Abu Hail"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":421200925,
-    "wof:lastmodified":1548974179,
-    "wof:name":"\u0627\u0628\u0648 \u0647\u064a\u0644",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Abu Hail",
     "wof:parent_id":1376833603,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/200/929/421200929.geojson
+++ b/data/421/200/929/421200929.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0631\u063a\u0645"
+    ],
+    "name:eng_x_preferred":[
+        "Margham"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200929,
-    "wof:lastmodified":1566581603,
-    "wof:name":"\u0645\u0631\u063a\u0645",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Margham",
     "wof:parent_id":1376833603,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/200/929/421200929.geojson
+++ b/data/421/200/929/421200929.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667983,
-        1376833603
+        1376833603,
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200929,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423090,
     "wof:name":"Margham",
     "wof:parent_id":1376833603,
     "wof:placetype":"locality",

--- a/data/421/201/803/421201803.geojson
+++ b/data/421/201/803/421201803.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667983,
-        1376833603
+        1376833603,
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421201803,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Aweer",
     "wof:parent_id":1376833603,
     "wof:placetype":"locality",

--- a/data/421/201/803/421201803.geojson
+++ b/data/421/201/803/421201803.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0639\u0648\u064a\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Al Aweer"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421201803,
-    "wof:lastmodified":1566581603,
-    "wof:name":"\u0627\u0644\u0639\u0648\u064a\u0631",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Aweer",
     "wof:parent_id":1376833603,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/201/805/421201805.geojson
+++ b/data/421/201/805/421201805.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55872714,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667983,
         102191569,
         85632573,
+        1376833603,
         421174961,
-        1376833603
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421201805,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423091,
     "wof:name":"Ras Al Khor",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/201/805/421201805.geojson
+++ b/data/421/201/805/421201805.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0631\u0627\u0633 \u0627\u0644\u062e\u0648\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Ras Al Khor"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421201805,
-    "wof:lastmodified":1566581603,
-    "wof:name":"\u0631\u0627\u0633 \u0627\u0644\u062e\u0648\u0631",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Ras Al Khor",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/203/275/421203275.geojson
+++ b/data/421/203/275/421203275.geojson
@@ -42,11 +42,11 @@
     "qs:woe_id":55873020,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85667983,
         102191569,
         85632573,
+        1376833603,
         421174961,
-        1376833603
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421203275,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Barsha 1",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/203/275/421203275.geojson
+++ b/data/421/203/275/421203275.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0628\u0631\u0634\u0627\u0621 1"
+    ],
+    "name:eng_x_preferred":[
+        "Al Barsha 1"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421203275,
-    "wof:lastmodified":1566581600,
-    "wof:name":"\u0627\u0644\u0628\u0631\u0634\u0627\u0621 1",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Al Barsha 1",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/203/281/421203281.geojson
+++ b/data/421/203/281/421203281.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0634\u0647\u0627\u0645\u0629 \u0627\u0644\u062c\u062f\u064a\u062f\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Shahama Al Jadeeda"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -55,8 +61,8 @@
         }
     ],
     "wof:id":421203281,
-    "wof:lastmodified":1548974184,
-    "wof:name":"\u0627\u0644\u0634\u0647\u0627\u0645\u0629 \u0627\u0644\u062c\u062f\u064a\u062f\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Shahama Al Jadeeda",
     "wof:parent_id":85667981,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-ae",

--- a/data/421/203/281/421203281.geojson
+++ b/data/421/203/281/421203281.geojson
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":421203281,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Shahama Al Jadeeda",
     "wof:parent_id":85667981,
     "wof:placetype":"county",

--- a/data/421/204/577/421204577.geojson
+++ b/data/421/204/577/421204577.geojson
@@ -42,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667981,
-        421172075
+        421172075,
+        85667981
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":421204577,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Bahyah",
     "wof:parent_id":421172075,
     "wof:placetype":"locality",

--- a/data/421/204/577/421204577.geojson
+++ b/data/421/204/577/421204577.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0628\u0627\u0647\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Bahyah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":421204577,
-    "wof:lastmodified":1548974185,
-    "wof:name":"\u0627\u0644\u0628\u0627\u0647\u064a\u0629",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Al Bahyah",
     "wof:parent_id":421172075,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-ae",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.