### PR TITLE
Add missing french name props

### DIFF
--- a/data/137/682/638/7/1376826387.geojson
+++ b/data/137/682/638/7/1376826387.geojson
@@ -43,6 +43,9 @@
     "name:fas_x_preferred":[
         "\u062f\u0628\u0627 \u0627\u0644\u062d\u0635\u0646"
     ],
+    "name:fra_x_preferred":[
+        "Dibba Al Hisn"
+    ],
     "name:ita_x_preferred":[
         "Dib\u0101"
     ],
@@ -86,7 +89,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1619191305,
+    "wof:lastmodified":1627507725,
     "wof:name":"Dibba Al-Hisn",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/638/9/1376826389.geojson
+++ b/data/137/682/638/9/1376826389.geojson
@@ -31,6 +31,9 @@
     "name:eng_x_preferred":[
         "Al Madam"
     ],
+    "name:fra_x_preferred":[
+        "Al Madam"
+    ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
@@ -59,7 +62,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1619191306,
+    "wof:lastmodified":1627507725,
     "wof:name":"Al Madam",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/639/1/1376826391.geojson
+++ b/data/137/682/639/1/1376826391.geojson
@@ -31,6 +31,9 @@
     "name:eng_x_preferred":[
         "Al Bataeh"
     ],
+    "name:fra_x_preferred":[
+        "Al Bataeh"
+    ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
@@ -59,7 +62,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1619191307,
+    "wof:lastmodified":1627507725,
     "wof:name":"Al Bataeh",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/639/3/1376826393.geojson
+++ b/data/137/682/639/3/1376826393.geojson
@@ -31,6 +31,9 @@
     "name:eng_x_preferred":[
         "Mleeha"
     ],
+    "name:fra_x_preferred":[
+        "Mliha"
+    ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
@@ -59,7 +62,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1619191308,
+    "wof:lastmodified":1627507725,
     "wof:name":"Mleeha",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/640/1/1376826401.geojson
+++ b/data/137/682/640/1/1376826401.geojson
@@ -31,6 +31,9 @@
     "name:eng_x_preferred":[
         "Al Hamriya"
     ],
+    "name:fra_x_preferred":[
+        "Al Hamriya"
+    ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
@@ -59,7 +62,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1619191311,
+    "wof:lastmodified":1627507725,
     "wof:name":"Al Hamriya",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/640/3/1376826403.geojson
+++ b/data/137/682/640/3/1376826403.geojson
@@ -43,6 +43,9 @@
     "name:eng_x_preferred":[
         "Al Dhafra"
     ],
+    "name:fra_x_preferred":[
+        "Al Gharbia"
+    ],
     "name:rus_x_preferred":[
         "\u042d\u0434-\u0414\u0430\u0444\u0440\u0430"
     ],
@@ -78,7 +81,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1616475290,
+    "wof:lastmodified":1627507725,
     "wof:name":"Al Dhafra",
     "wof:parent_id":85667981,
     "wof:placetype":"county",

--- a/data/421/176/643/421176643.geojson
+++ b/data/421/176/643/421176643.geojson
@@ -41,6 +41,9 @@
     "name:fas_x_preferred":[
         "\u0630\u06cc\u062f"
     ],
+    "name:fra_x_preferred":[
+        "Al Dhaid"
+    ],
     "name:nld_x_preferred":[
         "Dhaid"
     ],
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421176643,
-    "wof:lastmodified":1619191316,
+    "wof:lastmodified":1627507725,
     "wof:name":"Dhaid",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/856/679/63/85667963.geojson
+++ b/data/856/679/63/85667963.geojson
@@ -34,6 +34,9 @@
     "name:eng_x_preferred":[
         "Neutral Zone"
     ],
+    "name:fra_x_preferred":[
+        "Neutral Zone"
+    ],
     "name:hin_x_preferred":[
         "\u0928\u094d\u092f\u0942\u091f\u094d\u0930\u0932 \u091c\u093c\u094b\u0928 "
     ],
@@ -132,7 +135,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614896289,
+    "wof:lastmodified":1627507725,
     "wof:name":"Neutral Zone",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/73/85667973.geojson
+++ b/data/856/679/73/85667973.geojson
@@ -34,6 +34,9 @@
     "name:eng_x_preferred":[
         "Neutral Zone"
     ],
+    "name:fra_x_preferred":[
+        "Neutral Zone"
+    ],
     "name:hin_x_preferred":[
         "\u0928\u094d\u092f\u0942\u091f\u094d\u0930\u0932 \u091c\u093c\u094b\u0928"
     ],
@@ -132,7 +135,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614896289,
+    "wof:lastmodified":1627507725,
     "wof:name":"Neutral Zone",
     "wof:parent_id":85632573,
     "wof:placetype":"region",


### PR DESCRIPTION
This PR adds missing `name:fra_x_preferred` properties to "top-level" admin records (placetypes of country, macroregion, region, macrocounty, county). If this PR looks okay, I will process this same work in all other admin repos.

No PIP work needed, can merge once approved.