### PR TITLE
Update locality record

### DIFF
--- a/data/134/407/960/7/1344079607-alt-geonames.geojson
+++ b/data/134/407/960/7/1344079607-alt-geonames.geojson
@@ -1,0 +1,18 @@
+{
+  "id": 1344079607,
+  "type": "Feature",
+  "properties": {
+    "src:alt_label":"geonames",
+    "src:geom":"geonames",
+    "wof:geomhash":"2c892c02a3aa6db7f133777c183519e6",
+    "wof:id":1344079607,
+    "wof:repo":"whosonfirst-data-admin-ae"
+},
+  "bbox": [
+    56.07444,
+    25.9975,
+    56.07444,
+    25.9975
+],
+  "geometry": {"coordinates":[56.07444,25.9975],"type":"Point"}
+}

--- a/data/134/407/960/7/1344079607.geojson
+++ b/data/134/407/960/7/1344079607.geojson
@@ -4,11 +4,11 @@
   "properties": {
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
-    "geom:area":0.0,
+    "geom:area":0.000427,
     "geom:area_square_m":0.0,
-    "geom:bbox":"56.07444,25.9975,56.07444,25.9975",
-    "geom:latitude":25.9975,
-    "geom:longitude":56.07444,
+    "geom:bbox":"56.0689,25.988354,56.097368,26.017509",
+    "geom:latitude":26.004316,
+    "geom:longitude":56.083504,
     "gn:admin1_code":"05",
     "gn:asciiname":"Ghalilah",
     "gn:country_code":"AE",
@@ -38,7 +38,10 @@
     "name:und_x_variant":[
         "Ghal\u012blah"
     ],
-    "src:geom":"geonames",
+    "src:geom":"whosonfirst",
+    "src:geom_alt":[
+        "geonames"
+    ],
     "wof:belongsto":[
         102191569,
         85632573,
@@ -51,7 +54,10 @@
         "wk:page":"Ghalilah"
     },
     "wof:country":"AE",
-    "wof:geomhash":"2c892c02a3aa6db7f133777c183519e6",
+    "wof:geom_alt":[
+        "geonames"
+    ],
+    "wof:geomhash":"935988aeea84201314fb9f4a44d5f402",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -62,7 +68,7 @@
         }
     ],
     "wof:id":1344079607,
-    "wof:lastmodified":1663973839,
+    "wof:lastmodified":1687976990,
     "wof:name":"Ghalilah",
     "wof:parent_id":1376833605,
     "wof:placetype":"locality",
@@ -72,10 +78,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    56.07444,
-    25.9975,
-    56.07444,
-    25.9975
+    56.0689,
+    25.988354,
+    56.097368,
+    26.017509
 ],
-  "geometry": {"coordinates":[56.07444,25.9975],"type":"Point"}
+  "geometry": {"coordinates":[[[[56.079087,26.017509],[56.084117,26.016737],[56.084237,26.017157],[56.090892,26.015838],[56.09485,26.013889],[56.096709,26.01218],[56.097368,26.010591],[56.097038,26.003995],[56.096801,25.999542],[56.080246,26.001967],[56.079518,25.999117],[56.079518,25.997359],[56.080367,25.995054],[56.080852,25.99184],[56.081034,25.989172],[56.0689,25.988354],[56.07214,26.0],[56.074471,26.001638],[56.074528,26.00411],[56.077835,26.010778],[56.077805,26.013306],[56.078693,26.014111],[56.079087,26.017509]]]],"type":"MultiPolygon"}
 }


### PR DESCRIPTION
This PR adds a polygon to the locality record for Ghalilah. The existing point geometry is being stored as an alt.

The new polygon aligns with the parent records and doesn't overlap any other points/polygons at the neighbourhood/locality placetypes. No PIP work is needed here, can import this once approved.

**Number of records updated**: 2