### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/558/451/102558451.geojson
+++ b/data/102/558/451/102558451.geojson
@@ -35,6 +35,9 @@
     "name:fas_x_preferred":[
         "\u067e\u0627\u06cc\u06af\u0627\u0647 \u0647\u0648\u0627\u06cc\u06cc \u0627\u0644 \u0645\u06cc\u200c\u0646\u0647\u0627\u062f"
     ],
+    "name:fra_x_preferred":[
+        "Base a\u00e9rienne d'Al Minhad"
+    ],
     "name:jpn_x_preferred":[
         "\u30a2\u30eb\u30df\u30f3\u30cf\u30c9\u7a7a\u8ecd\u57fa\u5730"
     ],
@@ -43,6 +46,9 @@
     ],
     "name:nld_x_preferred":[
         "Vliegbasis Al Minhad"
+    ],
+    "name:pol_x_preferred":[
+        "Port lotniczy Al-Minhad"
     ],
     "name:por_x_preferred":[
         "Base A\u00e9rea de Al Minhad"
@@ -59,6 +65,9 @@
     "name:urd_x_preferred":[
         "\u0627\u0644\u0645\u0646\u06c1\u0627\u062f \u0627\u06cc\u0626\u0631 \u0628\u06cc\u0633"
     ],
+    "name:zho_x_preferred":[
+        "\u660e\u54c8\u5fb7\u7a7a\u519b\u57fa\u5730"
+    ],
     "oa:elevation_ft":"165",
     "oa:type":"medium_airport",
     "src:geom":"wikidata",
@@ -71,11 +80,11 @@
         "state_id":2347111
     },
     "wof:belongsto":[
-        85667983,
         102191569,
         85632573,
         421174961,
-        1376833603
+        1376833603,
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -99,7 +108,7 @@
         }
     ],
     "wof:id":102558451,
-    "wof:lastmodified":1663973547,
+    "wof:lastmodified":1690848510,
     "wof:name":"Minhad Air Base",
     "wof:parent_id":421174961,
     "wof:placetype":"campus",

--- a/data/102/558/457/102558457.geojson
+++ b/data/102/558/457/102558457.geojson
@@ -16,6 +16,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0637\u0627\u0631 \u0627\u0644\u062d\u0645\u0631\u0627"
     ],
+    "name:cym_x_preferred":[
+        "Maes Awyr Al Hamra Aux"
+    ],
     "name:eng_x_preferred":[
         "Al Hamra Aux Airport"
     ],
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":102558457,
-    "wof:lastmodified":1663973549,
+    "wof:lastmodified":1690848510,
     "wof:name":"Al Hamra aux Airport",
     "wof:parent_id":-1,
     "wof:placetype":"campus",

--- a/data/112/602/497/5/1126024975.geojson
+++ b/data/112/602/497/5/1126024975.geojson
@@ -26,6 +26,12 @@
     "name:ara_x_preferred":[
         "\u0639\u062c\u0645\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u0686\u0645\u0627\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Ajman"
+    ],
     "name:aze_x_preferred":[
         "\u018fcm\u0259n"
     ],
@@ -60,6 +66,9 @@
     "name:epo_x_preferred":[
         "A\u011dman"
     ],
+    "name:epo_x_variant":[
+        "A\u0135mano"
+    ],
     "name:est_x_preferred":[
         "\u2018Ajm\u0101n"
     ],
@@ -77,6 +86,9 @@
     ],
     "name:frp_x_preferred":[
         "Adj\u00b7man"
+    ],
+    "name:gle_x_preferred":[
+        "Ajman"
     ],
     "name:glg_x_preferred":[
         "Axman"
@@ -111,6 +123,9 @@
     "name:kan_x_preferred":[
         "\u0c85\u0c9c\u0ccd\u0cae\u0cbe\u0ca8\u0ccd"
     ],
+    "name:kat_x_preferred":[
+        "\u10d0\u10ef\u10db\u10d0\u10dc\u10d8"
+    ],
     "name:kor_x_preferred":[
         "\uc544\uc9c0\ub9cc"
     ],
@@ -119,6 +134,9 @@
     ],
     "name:lit_x_preferred":[
         "Ajmanas"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d05\u0d1c\u0d4d\u0d2e\u0d3e\u0d28\u0d4d\u200d"
     ],
     "name:mar_x_preferred":[
         "\u0905\u091c\u092e\u0928"
@@ -207,6 +225,9 @@
     "name:urd_x_preferred":[
         "\u0639\u062c\u0645\u0627\u0646"
     ],
+    "name:vec_x_preferred":[
+        "Ajm\u0101n"
+    ],
     "name:vie_x_preferred":[
         "Ajman"
     ],
@@ -272,7 +293,7 @@
         }
     ],
     "wof:id":1126024975,
-    "wof:lastmodified":1663974540,
+    "wof:lastmodified":1690848525,
     "wof:name":"Ajman",
     "wof:parent_id":1376833607,
     "wof:placetype":"locality",

--- a/data/137/683/360/3/1376833603.geojson
+++ b/data/137/683/360/3/1376833603.geojson
@@ -54,6 +54,9 @@
     "name:arz_x_preferred":[
         "\u062f\u0628\u0649"
     ],
+    "name:arz_x_variant":[
+        "\u0627\u0645\u0627\u0631\u0629 \u062f\u0628\u0649"
+    ],
     "name:asm_x_preferred":[
         "\u09a1\u09c1\u09ac\u09be\u0987"
     ],
@@ -112,6 +115,9 @@
     "name:ckb_x_preferred":[
         "\u062f\u0648\u0628\u06d5\u06cc"
     ],
+    "name:ckb_x_variant":[
+        "\u0645\u06cc\u0631\u0646\u0634\u06cc\u0646\u06cc \u062f\u0648\u0628\u06d5\u06cc"
+    ],
     "name:cor_x_preferred":[
         "Dubai"
     ],
@@ -120,6 +126,9 @@
     ],
     "name:dan_x_preferred":[
         "Dubai"
+    ],
+    "name:dan_x_variant":[
+        "Emiratet Dubai"
     ],
     "name:deu_x_preferred":[
         "Dubai"
@@ -200,6 +209,9 @@
     "name:hak_x_preferred":[
         "Dubai"
     ],
+    "name:hau_x_preferred":[
+        "Dubai"
+    ],
     "name:hbs_x_preferred":[
         "Dubai"
     ],
@@ -275,6 +287,9 @@
     "name:kaz_x_preferred":[
         "\u0414\u0443\u0431\u0430\u0439"
     ],
+    "name:khm_x_preferred":[
+        "\u1791\u17b8\u1780\u17d2\u179a\u17bb\u1784\u178c\u17bc\u1794\u17c3"
+    ],
     "name:kik_x_preferred":[
         "Dubai"
     ],
@@ -317,6 +332,9 @@
     "name:mkd_x_preferred":[
         "\u0414\u0443\u0431\u0430\u0438"
     ],
+    "name:mni_x_preferred":[
+        "\uabd7\uabe8\uabd5\uabe5\uabe2 \uabc2\uabe9\uabc4\uabe5\uabdb"
+    ],
     "name:mon_x_preferred":[
         "\u0414\u0443\u0431\u0430\u0439 \u0445\u043e\u0442"
     ],
@@ -326,6 +344,9 @@
     ],
     "name:msa_x_preferred":[
         "Dubai"
+    ],
+    "name:msa_x_variant":[
+        "Amiriah Dubai"
     ],
     "name:mya_x_preferred":[
         "\u1012\u1030\u1018\u102d\u102f\u1004\u103a\u1038\u1019\u103c\u102d\u102f\u1037"
@@ -663,7 +684,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1663974536,
+    "wof:lastmodified":1690848519,
     "wof:name":"Dubai",
     "wof:parent_id":85667983,
     "wof:placetype":"county",

--- a/data/137/683/360/5/1376833605.geojson
+++ b/data/137/683/360/5/1376833605.geojson
@@ -36,6 +36,9 @@
     "name:ara_x_variant":[
         "\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629"
+    ],
     "name:bel_x_preferred":[
         "\u042d\u043c\u0456\u0440\u0430\u0442 \u0420\u0430\u0441-\u044d\u043b\u044c-\u0425\u0430\u0439\u043c\u0430"
     ],
@@ -44,6 +47,12 @@
     ],
     "name:ben_x_preferred":[
         "\u09b0\u09be\u09b8 \u0986\u09b2-\u0996\u09be\u0987\u09ae\u09be\u09b9"
+    ],
+    "name:ben_x_variant":[
+        "\u09b0\u09be\u09b8 \u0986\u09b2 \u0996\u09be\u0987\u09ae\u09be\u09b9 \u0986\u09ae\u09bf\u09b0\u09be\u09a4"
+    ],
+    "name:bos_x_preferred":[
+        "Ras al-Khaimah"
     ],
     "name:bre_x_preferred":[
         "Ras al-Khaimah"
@@ -66,11 +75,17 @@
     "name:dan_x_preferred":[
         "Ras al-Khaimah"
     ],
+    "name:dan_x_variant":[
+        "Emiratet Ras al-Khaimah"
+    ],
     "name:deu_x_preferred":[
         "Ra\u2019s al-Chaima"
     ],
     "name:ell_x_preferred":[
         "\u03a1\u03b1\u03c2 \u03b1\u03bb-\u039a\u03b1\u03ca\u03bc\u03ac"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03bc\u03b9\u03c1\u03ac\u03c4\u03bf \u03c4\u03bf\u03c5 \u03a1\u03b1\u03c2 \u03b1\u03bb-\u03a7\u03b1\u03ca\u03bc\u03ac"
     ],
     "name:eng_x_preferred":[
         "Ras al Khaimah"
@@ -78,10 +93,14 @@
     "name:eng_x_variant":[
         "Ra's al Khaymah",
         "Ras al Khaymah",
-        "Ras al-Khaimah"
+        "Ras al-Khaimah",
+        "Emirate of Ras Al Khaimah"
     ],
     "name:epo_x_preferred":[
         "Ras-al-\u0124ajmo"
+    ],
+    "name:epo_x_variant":[
+        "Rasal\u0125ajmo"
     ],
     "name:est_x_preferred":[
         "Ra's al-Khaymah' emiraat"
@@ -97,6 +116,9 @@
     ],
     "name:fra_x_preferred":[
         "Ras el Kha\u00efmah"
+    ],
+    "name:glg_x_preferred":[
+        "Ras al-Jaimah"
     ],
     "name:guj_x_preferred":[
         "\u0ab0\u0abe\u0ab8 \u0a85\u0ab2-\u0a96\u0ac8\u0aae\u0abe\u0ab9"
@@ -126,8 +148,14 @@
         "\u054c\u0561\u057d-\u0561\u056c-\u053d\u0561\u0575\u0574\u0561\u0575\u056b \u0567\u0574\u056b\u0580\u0578\u0582\u0569\u0575\u0578\u0582\u0576",
         "\u054c\u0561\u057d \u0561\u056c-\u053d\u0561\u0575\u0574\u0561\u0575\u056b \u0537\u0574\u056b\u0580\u0578\u0582\u0569\u0575\u0578\u0582\u0576"
     ],
+    "name:hyw_x_preferred":[
+        "\u054c\u0561\u057d \u0561\u056c \u053d\u0561\u0575\u0574\u0561"
+    ],
     "name:ind_x_preferred":[
         "Ras al-Khaimah"
+    ],
+    "name:isl_x_preferred":[
+        "Ras al-Ka\u00edma"
     ],
     "name:ita_x_preferred":[
         "Ras al-Khaima"
@@ -167,6 +195,9 @@
     ],
     "name:msa_x_preferred":[
         "Ras al-Khaimah"
+    ],
+    "name:msa_x_variant":[
+        "Emiriah Ras al-Khaimah"
     ],
     "name:nan_x_preferred":[
         "Ras al-Khaimah"
@@ -252,11 +283,17 @@
     "name:tel_x_preferred":[
         "\u0c30\u0c3e\u0c38\u0c4d \u0c05\u0c32\u0c4d-\u0c16\u0c48\u0c2e\u0c3e"
     ],
+    "name:tgk_x_preferred":[
+        "\u0420\u0430\u044a\u0441\u0443-\u043b-\u0425\u0430\u0439\u043c\u0430"
+    ],
     "name:tgl_x_preferred":[
         "Ras al-Khaimah"
     ],
     "name:tha_x_preferred":[
         "\u0e23\u0e31\u0e10\u0e23\u0e32\u0e2a\u0e2d\u0e31\u0e25\u0e44\u0e04\u0e21\u0e32\u0e2b\u0e4c"
+    ],
+    "name:tha_x_variant":[
+        "\u0e23\u0e31\u0e10\u0e40\u0e23\u0e32\u0e30\u0e0b\u0e38\u0e25\u0e04\u0e31\u0e22\u0e21\u0e30\u0e2e\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Res\u00fc'l-Hayme"
@@ -279,6 +316,9 @@
     "name:war_x_preferred":[
         "Ras al-Kaimah"
     ],
+    "name:wuu_x_preferred":[
+        "\u54c8\u4f0a\u9a6c\u89d2\u914b\u957f\u56fd"
+    ],
     "name:xmf_x_preferred":[
         "\u10e0\u10d0\u10e1-\u10d4\u10da-\u10ee\u10d0\u10d8\u10db\u10d0\u10e8 \u10e1\u10d0\u10d0\u10db\u10d8\u10e0\u10dd"
     ],
@@ -290,6 +330,9 @@
     ],
     "name:zho_x_preferred":[
         "\u62c9\u65af\u6d77\u739b"
+    ],
+    "name:zho_x_variant":[
+        "\u62c9\u65af\u6d77\u746a\u914b\u9577\u570b"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ARE",
@@ -420,7 +463,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1663974536,
+    "wof:lastmodified":1690848519,
     "wof:name":"Ras Al Khaimah",
     "wof:parent_id":85667951,
     "wof:placetype":"county",

--- a/data/137/683/360/7/1376833607.geojson
+++ b/data/137/683/360/7/1376833607.geojson
@@ -48,6 +48,12 @@
     "name:ben_x_preferred":[
         "\u0986\u099c\u09ae\u09be\u09a8 \u098f\u09ae\u09bf\u09b0\u09be\u09a4"
     ],
+    "name:ben_x_variant":[
+        "\u0986\u099c\u09ae\u09be\u09a8 \u0986\u09ae\u09bf\u09b0\u09be\u09a4"
+    ],
+    "name:bos_x_preferred":[
+        "Ajman"
+    ],
     "name:bre_x_preferred":[
         "Ajman"
     ],
@@ -63,14 +69,23 @@
     "name:ces_x_preferred":[
         "Ad\u017em\u00e1n"
     ],
+    "name:dag_x_preferred":[
+        "Ajman"
+    ],
     "name:dan_x_preferred":[
         "Ajman"
+    ],
+    "name:dan_x_variant":[
+        "Emiratet Ajman"
     ],
     "name:deu_x_preferred":[
         "Adschman"
     ],
     "name:ell_x_preferred":[
         "\u0391\u03ca\u03bc\u03ac\u03bd"
+    ],
+    "name:ell_x_variant":[
+        "\u0391\u03c4\u03b6\u03bc\u03ac\u03bd"
     ],
     "name:eng_x_preferred":[
         "Ajman"
@@ -184,6 +199,9 @@
     "name:nan_x_preferred":[
         "Ajman Th\u00e2u-l\u00e2ng-kok"
     ],
+    "name:nep_x_preferred":[
+        "\u0905\u091c\u092e\u093e\u0928 \u0907\u092e\u093f\u0930\u0947\u091f\u094d\u0938"
+    ],
     "name:nld_x_preferred":[
         "Ajman"
     ],
@@ -262,6 +280,9 @@
     "name:tha_x_preferred":[
         "\u0e23\u0e31\u0e10\u0e2d\u0e31\u0e08\u0e21\u0e32\u0e19"
     ],
+    "name:tha_x_variant":[
+        "\u0e23\u0e31\u0e10\u0e2d\u0e31\u0e08\u0e0d\u0e4c\u0e21\u0e32\u0e19"
+    ],
     "name:tur_x_preferred":[
         "Acman"
     ],
@@ -277,6 +298,9 @@
     "name:vie_x_preferred":[
         "Ajman"
     ],
+    "name:wuu_x_preferred":[
+        "\u963f\u6cbb\u66fc\u914b\u957f\u56fd"
+    ],
     "name:xmf_x_preferred":[
         "\u10d0\u10ef\u10db\u10d0\u10dc\u10d8\u10e8 \u10e1\u10d0\u10d0\u10db\u10d8\u10e0\u10dd"
     ],
@@ -288,6 +312,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u5409\u66fc"
+    ],
+    "name:zho_x_variant":[
+        "\u963f\u6cbb\u66fc\u914b\u957f\u56fd"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ARE",
@@ -418,7 +445,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1663974536,
+    "wof:lastmodified":1690848518,
     "wof:name":"Ajman",
     "wof:parent_id":85667969,
     "wof:placetype":"county",

--- a/data/137/683/360/9/1376833609.geojson
+++ b/data/137/683/360/9/1376833609.geojson
@@ -36,6 +36,9 @@
     "name:ast_x_preferred":[
         "Emiratu d'Umm al-Qaywayn"
     ],
+    "name:aze_x_preferred":[
+        "\u00dcmm \u0259l-Qeyveyn \u0259mirliyi"
+    ],
     "name:bel_x_preferred":[
         "\u042d\u043c\u0456\u0440\u0430\u0442 \u0423\u043c-\u044d\u043b\u044c-\u041a\u0430\u0439\u0432\u0430\u0439\u043d"
     ],
@@ -44,6 +47,12 @@
     ],
     "name:ben_x_preferred":[
         "\u0989\u09ae\u09cd\u09ae\u09c1\u09b2 \u0995\u09c1\u09af\u09bc\u09be\u0987\u09a8"
+    ],
+    "name:ben_x_variant":[
+        "\u0989\u09ae\u09cd\u09ae \u0986\u09b2 \u0995\u09cb\u09af\u09bc\u09be\u0987\u09a8 \u0986\u09ae\u09bf\u09b0\u09be\u09a4"
+    ],
+    "name:bos_x_preferred":[
+        "Umm al-Quwain"
     ],
     "name:bre_x_preferred":[
         "Umm al-Qaywayn"
@@ -63,6 +72,9 @@
     "name:dan_x_preferred":[
         "Umm Al Quwain"
     ],
+    "name:dan_x_variant":[
+        "Emiratet Umm Al Quwain"
+    ],
     "name:deu_x_preferred":[
         "Umm al-Qaiwain"
     ],
@@ -74,10 +86,14 @@
     ],
     "name:eng_x_variant":[
         "Umm al Qaywayn",
-        "Umm al-Quwain"
+        "Umm al-Quwain",
+        "Emirate of Umm Al Quwain"
     ],
     "name:epo_x_preferred":[
         "Um-al-Kajvajno"
+    ],
+    "name:epo_x_variant":[
+        "Umalkajvajno"
     ],
     "name:est_x_preferred":[
         "Umm al-Qaywayni emiraat"
@@ -250,6 +266,9 @@
     "name:tha_x_preferred":[
         "\u0e23\u0e31\u0e10\u0e2d\u0e38\u0e21\u0e21\u0e4c\u0e2d\u0e31\u0e25\u0e44\u0e01\u0e44\u0e27\u0e19\u0e4c"
     ],
+    "name:tha_x_variant":[
+        "\u0e23\u0e31\u0e10\u0e2d\u0e38\u0e21\u0e21\u0e4c\u0e2d\u0e31\u0e25\u0e01\u0e38\u0e40\u0e27\u0e19"
+    ],
     "name:tur_x_preferred":[
         "Umm\u00fcl-Kayveyn Emirli\u011fi"
     ],
@@ -265,6 +284,12 @@
     "name:vie_x_preferred":[
         "Umm al-Quwain"
     ],
+    "name:war_x_preferred":[
+        "Emirato han Umm Al Quwain"
+    ],
+    "name:wuu_x_preferred":[
+        "\u4e4c\u59c6\u76d6\u4e07\u914b\u957f\u56fd"
+    ],
     "name:xmf_x_preferred":[
         "\u10e3\u10db-\u10d4\u10da-\u10e5\u10d0\u10d8\u10d5\u10d0\u10d8\u10dc\u10d8\u10e8 \u10e1\u10d0\u10d0\u10db\u10d8\u10e0\u10dd"
     ],
@@ -274,11 +299,15 @@
     "name:yue_x_preferred":[
         "\u6b50\u59c6\u53e4\u6eab\u914b\u9577\u570b"
     ],
+    "name:yue_x_variant":[
+        "\u70cf\u59c6\u84cb\u842c\u914b\u9577\u570b"
+    ],
     "name:zho_x_preferred":[
         "\u70cf\u59c6\u84cb\u842c"
     ],
     "name:zho_x_variant":[
-        "\u6b27\u59c6\u53e4\u6e29"
+        "\u6b27\u59c6\u53e4\u6e29",
+        "\u4e4c\u59c6\u76d6\u4e07\u914b\u957f\u56fd"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ARE",
@@ -415,7 +444,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1663974536,
+    "wof:lastmodified":1690848518,
     "wof:name":"Umm Al Quwain",
     "wof:parent_id":85667955,
     "wof:placetype":"county",

--- a/data/137/683/361/1/1376833611.geojson
+++ b/data/137/683/361/1/1376833611.geojson
@@ -33,8 +33,14 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0641\u062c\u064a\u0631\u0629"
     ],
+    "name:ara_x_variant":[
+        "\u0625\u0645\u0627\u0631\u0629 \u0627\u0644\u0641\u062c\u064a\u0631\u0629"
+    ],
     "name:aze_x_preferred":[
         "\u018fl-F\u00fcceyr\u0259 \u0259mirliyi"
+    ],
+    "name:bak_x_preferred":[
+        "\u04d8\u043b-\u0424\u04af\u0436\u04d9\u0439\u0440\u04d9"
     ],
     "name:bel_x_preferred":[
         "\u042d\u043c\u0456\u0440\u0430\u0442 \u042d\u043b\u044c-\u0424\u0443\u0434\u0436\u0430\u0439\u0440\u0430"
@@ -44,6 +50,12 @@
     ],
     "name:ben_x_preferred":[
         "\u09ab\u09c1\u099c\u09be\u09af\u09bc\u09b0\u09be"
+    ],
+    "name:ben_x_variant":[
+        "\u09ab\u09c1\u099c\u09be\u0987\u09b0\u09be\u09b9 \u0986\u09ae\u09bf\u09b0\u09be\u09a4"
+    ],
+    "name:bos_x_preferred":[
+        "Fujairah"
     ],
     "name:bre_x_preferred":[
         "Fujayrah"
@@ -62,6 +74,9 @@
     ],
     "name:dan_x_preferred":[
         "Fujairah"
+    ],
+    "name:dan_x_variant":[
+        "Emiratet Fujairah"
     ],
     "name:deu_x_preferred":[
         "Fudschaira"
@@ -118,6 +133,9 @@
     "name:ind_x_preferred":[
         "Fujairah"
     ],
+    "name:isl_x_preferred":[
+        "F\u00fadsa\u00edra"
+    ],
     "name:ita_x_preferred":[
         "Fujaira"
     ],
@@ -126,6 +144,9 @@
     ],
     "name:kan_x_preferred":[
         "\u0cab\u0cc1\u0c9c\u0cc8\u0cb0\u0cbe"
+    ],
+    "name:kat_x_preferred":[
+        "\u10d0\u10da-\u10e4\u10e3\u10ef\u10d0\u10d8\u10e0\u10d0\u10e1 \u10e1\u10d0\u10d0\u10db\u10d8\u10e0\u10dd"
     ],
     "name:kor_x_preferred":[
         "\ud478\uc790\uc774\ub77c \ud1a0\ud6c4\uad6d"
@@ -265,6 +286,9 @@
     "name:vie_x_preferred":[
         "Fujairah"
     ],
+    "name:wuu_x_preferred":[
+        "\u5bcc\u67e5\u4f0a\u62c9\u914b\u957f\u56fd"
+    ],
     "name:xmf_x_preferred":[
         "\u10d4\u10da-\u10e4\u10e3\u10ef\u10d0\u10d8\u10e0\u10d0\u10e8 \u10e1\u10d0\u10d0\u10db\u10d8\u10e0\u10dd"
     ],
@@ -276,6 +300,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5bcc\u5409\u62c9"
+    ],
+    "name:zho_x_variant":[
+        "\u5bcc\u67e5\u4f0a\u62c9\u914b\u957f\u56fd"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ARE",
@@ -409,7 +436,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1663974536,
+    "wof:lastmodified":1690848518,
     "wof:name":"Fujairah",
     "wof:parent_id":85667959,
     "wof:placetype":"county",

--- a/data/179/632/910/3/1796329103.geojson
+++ b/data/179/632/910/3/1796329103.geojson
@@ -16,12 +16,40 @@
     "name:ara_x_preferred":[
         "\u0671\u0644\u0640\u0633\u0650\u0651\u0640\u0644\u064e\u0640\u0639"
     ],
+    "name:ara_x_variant":[
+        "\u0627\u0644\u0633\u0644\u0639"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0633\u0644\u0639"
+    ],
+    "name:deu_x_preferred":[
+        "Sila"
+    ],
     "name:eng_x_preferred":[
         "As-Sila"
     ],
     "name:eng_x_variant":[
         "As Sila",
-        "Al Sila"
+        "Al Sila",
+        "Sila"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0633\u0644\u0639"
+    ],
+    "name:fra_x_preferred":[
+        "Sila"
+    ],
+    "name:ita_x_preferred":[
+        "Sila"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d38\u0d4d\u0d35\u0d3f\u0d32"
+    ],
+    "name:nld_x_preferred":[
+        "Sila"
+    ],
+    "name:pol_x_preferred":[
+        "Sila"
     ],
     "reversegeo:latitude":24.066591,
     "reversegeo:longitude":51.760032,
@@ -49,7 +77,7 @@
         }
     ],
     "wof:id":1796329103,
-    "wof:lastmodified":1663974544,
+    "wof:lastmodified":1690848525,
     "wof:name":"As-Sila",
     "wof:parent_id":1376826403,
     "wof:placetype":"locality",

--- a/data/421/168/683/421168683.geojson
+++ b/data/421/168/683/421168683.geojson
@@ -32,6 +32,9 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0634\u0627\u0631\u0642\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Sharjah"
+    ],
     "name:azb_x_preferred":[
         "\u0634\u0627\u0631\u062c\u0647"
     ],
@@ -43,6 +46,9 @@
     ],
     "name:bel_x_variant":[
         "\u0428\u0430\u0440\u0434\u0436\u0430"
+    ],
+    "name:ben_x_preferred":[
+        "\u09b6\u09be\u09b0\u099c\u09be\u09b9"
     ],
     "name:bre_x_preferred":[
         "Charjah"
@@ -91,6 +97,12 @@
     ],
     "name:frp_x_preferred":[
         "Ch\u00b7ardj\u00b7a"
+    ],
+    "name:gle_x_preferred":[
+        "Sharjah"
+    ],
+    "name:hau_x_preferred":[
+        "Sharjah"
     ],
     "name:hbs_x_preferred":[
         "\u0160ard\u017ea"
@@ -161,6 +173,9 @@
     "name:mkd_x_preferred":[
         "\u0428\u0430\u0440\u045f\u0430"
     ],
+    "name:msa_x_preferred":[
+        "Sharjah"
+    ],
     "name:nld_x_preferred":[
         "Sharjah"
     ],
@@ -179,6 +194,9 @@
     "name:pnb_x_preferred":[
         "\u0634\u0627\u0631\u062c\u06c1"
     ],
+    "name:pnb_x_variant":[
+        "\u0634\u0627\u0631\u062c\u0627"
+    ],
     "name:pol_x_preferred":[
         "Szard\u017ca"
     ],
@@ -187,6 +205,9 @@
     ],
     "name:por_x_variant":[
         "Xarja"
+    ],
+    "name:pus_x_preferred":[
+        "\u0634\u0627\u0631\u062c\u0647"
     ],
     "name:ron_x_preferred":[
         "Sharjah"
@@ -233,6 +254,9 @@
     "name:tur_x_preferred":[
         "\u015earika"
     ],
+    "name:uig_x_preferred":[
+        "\u0634\u0627\u0631\u062c\u0627"
+    ],
     "name:ukr_x_preferred":[
         "\u0428\u0430\u0440\u0434\u0436\u0430"
     ],
@@ -242,11 +266,20 @@
     "name:urd_x_preferred":[
         "\u0634\u0627\u0631\u062c\u06c1"
     ],
+    "name:uzb_x_preferred":[
+        "Sharja"
+    ],
+    "name:vec_x_preferred":[
+        "Sharja"
+    ],
     "name:vie_x_preferred":[
         "Sharjah"
     ],
     "name:war_x_preferred":[
         "Sharjah"
+    ],
+    "name:wuu_x_preferred":[
+        "\u6c99\u8fe6"
     ],
     "name:xmf_x_preferred":[
         "\u10e8\u10d0\u10e0\u10ef\u10d0"
@@ -410,7 +443,7 @@
         }
     ],
     "wof:id":421168683,
-    "wof:lastmodified":1663974536,
+    "wof:lastmodified":1690848520,
     "wof:name":"Sharjah",
     "wof:parent_id":421171391,
     "wof:placetype":"locality",

--- a/data/421/168/685/421168685.geojson
+++ b/data/421/168/685/421168685.geojson
@@ -29,6 +29,9 @@
     "name:ara_x_variant":[
         "\u0641\u062c\u064a\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0641\u062c\u064a\u0631\u0647"
+    ],
     "name:ast_x_preferred":[
         "Fuyaira"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:bel_x_preferred":[
         "\u042d\u043b\u044c-\u0424\u0443\u0434\u0436\u0430\u0439\u0440\u0430"
+    ],
+    "name:ben_x_preferred":[
+        "\u09ab\u09c1\u099c\u09be\u0987\u09b0\u09be\u09b9"
     ],
     "name:bre_x_preferred":[
         "Fujayrah"
@@ -61,6 +67,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a6\u03bf\u03c5\u03c4\u03b6\u03ad\u03b9\u03c1\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u03a6\u03bf\u03c5\u03b6\u03b1\u0390\u03c1\u03b1"
     ],
     "name:eng_x_preferred":[
         "Fujairah"
@@ -119,6 +128,9 @@
     "name:jpn_x_variant":[
         "\u30d5\u30b8\u30e3\u30a4\u30e9\u5e02"
     ],
+    "name:kat_x_preferred":[
+        "\u10d0\u10da-\u10e4\u10e3\u10ef\u10d0\u10d8\u10e0\u10d0"
+    ],
     "name:kor_x_preferred":[
         "\ud478\uc790\uc774\ub77c"
     ],
@@ -127,6 +139,9 @@
     ],
     "name:lav_x_preferred":[
         "Fud\u017eeiras emir\u0101ts"
+    ],
+    "name:lav_x_variant":[
+        "Fud\u017eeira"
     ],
     "name:lit_x_preferred":[
         "Fud\u017eeira"
@@ -227,10 +242,16 @@
     "name:urd_x_preferred":[
         "\u0641\u062c\u06cc\u0631\u06c1"
     ],
+    "name:urd_x_variant":[
+        "\u0641\u062c\u06cc\u0631\u06c1 \u0634\u06c1\u0631"
+    ],
     "name:uzb_x_preferred":[
         "Fujayra"
     ],
     "name:vie_x_preferred":[
+        "Fujairah"
+    ],
+    "name:war_x_preferred":[
         "Fujairah"
     ],
     "name:xmf_x_preferred":[
@@ -247,6 +268,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5bcc\u5409\u62c9"
+    ],
+    "name:zho_x_variant":[
+        "\u5bcc\u67e5\u4f0a\u62c9"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"United Arab Emirates",
@@ -398,7 +422,7 @@
         }
     ],
     "wof:id":421168685,
-    "wof:lastmodified":1663974536,
+    "wof:lastmodified":1690848520,
     "wof:name":"Fujairah",
     "wof:parent_id":1376833611,
     "wof:placetype":"locality",

--- a/data/421/168/687/421168687.geojson
+++ b/data/421/168/687/421168687.geojson
@@ -20,6 +20,9 @@
     "mz:is_current":1,
     "mz:min_zoom":6.7,
     "mz:note":"quattroshapes points import (201603)",
+    "name:afr_x_preferred":[
+        "Al Ain"
+    ],
     "name:ara_x_preferred":[
         "\u0627\u0644\u0639\u064a\u0646"
     ],
@@ -27,11 +30,20 @@
         "Al \u2018Ayn",
         "\u0627\u0644\u0639\u064a\u0646\u060c \u0623\u0628\u0648\u0638\u0628\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0639\u064a\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Al Ain"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0639\u06cc\u0646"
     ],
     "name:ben_x_preferred":[
         "\u0986\u09b2 \u0986\u0987\u09a8"
+    ],
+    "name:bul_x_preferred":[
+        "\u0410\u0439\u043d"
     ],
     "name:cat_x_preferred":[
         "Al-Ain"
@@ -41,6 +53,9 @@
     ],
     "name:ces_x_preferred":[
         "Al Ajn"
+    ],
+    "name:ces_x_variant":[
+        "al-Ajn"
     ],
     "name:dan_x_preferred":[
         "Al-Ain"
@@ -68,6 +83,9 @@
     ],
     "name:fra_x_preferred":[
         "Al-A\u00efn"
+    ],
+    "name:gle_x_preferred":[
+        "Al Ain"
     ],
     "name:guj_x_preferred":[
         "\u0a85\u0ab2 \u0a86\u0a88\u0aa8"
@@ -141,6 +159,9 @@
     "name:mar_x_preferred":[
         "\u0905\u0932 \u0910\u0928"
     ],
+    "name:mkd_x_preferred":[
+        "\u0415\u043b \u0410\u0458\u043d"
+    ],
     "name:mon_x_preferred":[
         "\u0410\u043b\u044c-\u0410\u0439\u043d"
     ],
@@ -198,6 +219,9 @@
     "name:swe_x_preferred":[
         "Al Ain"
     ],
+    "name:szl_x_preferred":[
+        "Al-Ajn"
+    ],
     "name:tam_x_preferred":[
         "\u0b85\u0bb2\u0bcd \u0b90\u0ba9\u0bcd"
     ],
@@ -207,11 +231,17 @@
     "name:tel_x_preferred":[
         "\u0c05\u0c32\u0c4d\u0c10\u0c28\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0410\u043b\u044a\u0430\u0439\u043d"
+    ],
     "name:tgl_x_preferred":[
         "Al Ain"
     ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e31\u0e25 \u0e44\u0e2d\u0e19\u0e4c"
+    ],
+    "name:tha_x_variant":[
+        "\u0e2d\u0e31\u0e25\u0e2d\u0e31\u0e22\u0e19\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Al Ain"
@@ -230,6 +260,9 @@
     ],
     "name:uzb_x_preferred":[
         "Al Ayn"
+    ],
+    "name:vec_x_preferred":[
+        "Al-'Ayn"
     ],
     "name:vep_x_preferred":[
         "El Ain"
@@ -395,7 +428,7 @@
         }
     ],
     "wof:id":421168687,
-    "wof:lastmodified":1663974536,
+    "wof:lastmodified":1690848519,
     "wof:name":"Al Ain",
     "wof:parent_id":421200931,
     "wof:placetype":"locality",

--- a/data/421/169/933/421169933.geojson
+++ b/data/421/169/933/421169933.geojson
@@ -80,6 +80,9 @@
     "name:rus_x_variant":[
         "\u0414\u0435\u0439\u0440\u0430"
     ],
+    "name:spa_x_preferred":[
+        "Deira"
+    ],
     "name:swe_x_preferred":[
         "Corniche"
     ],
@@ -94,6 +97,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0414\u0435\u0439\u0440\u0430"
+    ],
+    "name:urd_x_preferred":[
+        "\u062f\u06cc\u0631\u06c1"
     ],
     "name:vie_x_preferred":[
         "Deira"
@@ -155,7 +161,7 @@
         }
     ],
     "wof:id":421169933,
-    "wof:lastmodified":1663974537,
+    "wof:lastmodified":1690848521,
     "wof:name":"Corniche Deira",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/171/849/421171849.geojson
+++ b/data/421/171/849/421171849.geojson
@@ -29,6 +29,9 @@
     "name:eng_x_variant":[
         "Al Hudheiba"
     ],
+    "name:epo_x_preferred":[
+        "Alhudajba"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u062d\u0636\u06cc\u0628\u0629"
     ],
@@ -40,6 +43,12 @@
     ],
     "name:ita_x_preferred":[
         "Al Hudaiba"
+    ],
+    "name:nld_x_preferred":[
+        "Al Hudaiba"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u062d\u0636\u06cc\u0628\u06c1"
     ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
@@ -98,7 +107,7 @@
         }
     ],
     "wof:id":421171849,
-    "wof:lastmodified":1663974539,
+    "wof:lastmodified":1690848524,
     "wof:name":"Al Hudaiba",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/174/605/421174605.geojson
+++ b/data/421/174/605/421174605.geojson
@@ -44,6 +44,9 @@
     "name:und_x_variant":[
         "Ruq\u2018at Mu\u1e29a\u015f\u015fanah"
     ],
+    "name:urd_x_preferred":[
+        "\u0645\u062d\u06cc\u0635\u0646\u06c1"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":291021,
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421174605,
-    "wof:lastmodified":1663974537,
+    "wof:lastmodified":1690848521,
     "wof:name":"Muhaisnah",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/174/961/421174961.geojson
+++ b/data/421/174/961/421174961.geojson
@@ -26,6 +26,9 @@
     "name:afr_x_preferred":[
         "Doebai"
     ],
+    "name:aka_x_preferred":[
+        "Dubai"
+    ],
     "name:als_x_preferred":[
         "Dubai"
     ],
@@ -41,6 +44,9 @@
     "name:arg_x_preferred":[
         "Dubai"
     ],
+    "name:ary_x_preferred":[
+        "\u062f\u0628\u064a"
+    ],
     "name:arz_x_preferred":[
         "\u062f\u0628\u0649"
     ],
@@ -52,6 +58,9 @@
     ],
     "name:ast_x_variant":[
         "Dub\u00e1i"
+    ],
+    "name:ava_x_preferred":[
+        "\u0414\u0443\u0431\u0430\u0439"
     ],
     "name:azb_x_preferred":[
         "\u062f\u0648\u0628\u06cc"
@@ -104,6 +113,9 @@
     "name:che_x_preferred":[
         "\u0414\u0443\u0431\u0430\u0439"
     ],
+    "name:chu_x_preferred":[
+        "\u0414\u043e\u0443\u0431\u0430\u0438"
+    ],
     "name:chv_x_preferred":[
         "\u0414\u0443\u0431\u0430\u0439"
     ],
@@ -113,7 +125,13 @@
     "name:cor_x_preferred":[
         "Dubai"
     ],
+    "name:crh_x_preferred":[
+        "Dubay"
+    ],
     "name:cym_x_preferred":[
+        "Dubai"
+    ],
+    "name:dag_x_preferred":[
         "Dubai"
     ],
     "name:dan_x_preferred":[
@@ -136,6 +154,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039d\u03c4\u03bf\u03c5\u03bc\u03c0\u03ac\u03b9"
+    ],
+    "name:eml_x_preferred":[
+        "Dubai"
     ],
     "name:eng_ca_x_preferred":[
         "Dubai"
@@ -188,6 +209,9 @@
     "name:fry_x_variant":[
         "D\u00fbbai"
     ],
+    "name:gla_x_preferred":[
+        "Dubai"
+    ],
     "name:gle_x_preferred":[
         "Dubai"
     ],
@@ -236,6 +260,9 @@
     "name:ido_x_preferred":[
         "Dubai"
     ],
+    "name:ile_x_preferred":[
+        "Dubai"
+    ],
     "name:ilo_x_preferred":[
         "Dubai"
     ],
@@ -269,11 +296,17 @@
     "name:kan_x_preferred":[
         "\u0ca6\u0cc1\u0cac\u0cc8"
     ],
+    "name:kas_x_preferred":[
+        "\u062f\u064f\u0628\u0627\u06cc\u0620"
+    ],
     "name:kat_x_preferred":[
         "\u10d3\u10e3\u10d1\u10d0\u10d8"
     ],
     "name:kaz_x_preferred":[
         "\u0414\u0443\u0431\u0430\u0439"
+    ],
+    "name:khm_x_preferred":[
+        "\u178c\u17bc\u1794\u17c3"
     ],
     "name:kik_x_preferred":[
         "Dubai"
@@ -299,6 +332,12 @@
     "name:lez_x_preferred":[
         "\u0414\u0443\u0431\u0430\u0439"
     ],
+    "name:lij_x_preferred":[
+        "Dubai"
+    ],
+    "name:lim_x_preferred":[
+        "Dubai"
+    ],
     "name:lit_x_preferred":[
         "Dubajus"
     ],
@@ -323,8 +362,17 @@
     "name:mkd_x_preferred":[
         "\u0414\u0443\u0431\u0430\u0438"
     ],
+    "name:mlt_x_preferred":[
+        "Dubaj"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd7\uabe8\uabd5\uabe5\uabe2"
+    ],
     "name:mon_x_preferred":[
         "\u0414\u0443\u0431\u0430\u0439 \u0445\u043e\u0442"
+    ],
+    "name:mri_x_preferred":[
+        "T\u016bpai"
     ],
     "name:msa_x_preferred":[
         "Dubai"
@@ -395,6 +443,9 @@
     "name:pus_x_preferred":[
         "\u062f\u0648\u0628\u06cd"
     ],
+    "name:que_x_preferred":[
+        "Thupayi"
+    ],
     "name:ron_x_preferred":[
         "Dubai"
     ],
@@ -419,6 +470,9 @@
     "name:sgs_x_preferred":[
         "Dubajos"
     ],
+    "name:sgs_x_variant":[
+        "Dobajos"
+    ],
     "name:sin_x_preferred":[
         "\u0da9\u0dd4\u0db6\u0dcf\u0dba\u0dd2"
     ],
@@ -441,6 +495,9 @@
         "Dub\u00e1i"
     ],
     "name:sqi_x_preferred":[
+        "Dubai"
+    ],
+    "name:srd_x_preferred":[
         "Dubai"
     ],
     "name:srp_x_preferred":[
@@ -467,6 +524,9 @@
     "name:tel_x_preferred":[
         "\u0c26\u0c41\u0c2c\u0c3e\u0c2f\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0414\u0443\u0431\u0430\u0439"
+    ],
     "name:tgl_x_preferred":[
         "Dubai"
     ],
@@ -482,6 +542,9 @@
     "name:uig_x_preferred":[
         "\u062f\u06c7\u0628\u0627\u0626\u0649"
     ],
+    "name:uig_x_variant":[
+        "\u062f\u06c7\u0628\u06d5\u064a"
+    ],
     "name:ukr_x_preferred":[
         "\u0414\u0443\u0431\u0430\u0439"
     ],
@@ -494,11 +557,17 @@
     "name:uzb_x_preferred":[
         "Dubay"
     ],
+    "name:vec_x_preferred":[
+        "Dubai"
+    ],
     "name:vep_x_preferred":[
         "Dubai"
     ],
     "name:vie_x_preferred":[
         "Dubai"
+    ],
+    "name:vol_x_preferred":[
+        "Dubayy"
     ],
     "name:war_x_preferred":[
         "Dubai"
@@ -675,7 +744,7 @@
         }
     ],
     "wof:id":421174961,
-    "wof:lastmodified":1663974537,
+    "wof:lastmodified":1690848521,
     "wof:megacity":1,
     "wof:name":"Dubai",
     "wof:parent_id":1376833603,

--- a/data/421/179/641/421179641.geojson
+++ b/data/421/179/641/421179641.geojson
@@ -26,6 +26,9 @@
     "name:afr_x_preferred":[
         "Aboe Dhabi"
     ],
+    "name:aka_x_preferred":[
+        "Abu Dhabi"
+    ],
     "name:als_x_preferred":[
         "Abu Dhabi"
     ],
@@ -40,6 +43,12 @@
     ],
     "name:ara_x_variant":[
         "\u0623\u0628\u0648\u0638\u0628\u064a"
+    ],
+    "name:arg_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:ary_x_preferred":[
+        "\u0623\u0628\u0648 \u0636\u0627\u0628\u064a"
     ],
     "name:arz_x_preferred":[
         "\u0627\u0628\u0648 \u0638\u0628\u0649"
@@ -64,6 +73,9 @@
     ],
     "name:bak_x_preferred":[
         "\u04d8\u0431\u04af-\u0414\u04d9\u0431\u0438"
+    ],
+    "name:ban_x_preferred":[
+        "Abu Dhabi"
     ],
     "name:bcl_x_preferred":[
         "Abu Dhabi"
@@ -150,6 +162,9 @@
     "name:epo_x_preferred":[
         "Abu-Dabio"
     ],
+    "name:epo_x_variant":[
+        "Abudabio"
+    ],
     "name:est_x_preferred":[
         "Abu Dhabi emiraat"
     ],
@@ -157,6 +172,9 @@
         "Abu Dhabi"
     ],
     "name:eus_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:fao_x_preferred":[
         "Abu Dhabi"
     ],
     "name:fas_x_preferred":[
@@ -198,6 +216,9 @@
     "name:hat_x_preferred":[
         "Abou Dabi"
     ],
+    "name:hau_x_preferred":[
+        "Abu Dhabi"
+    ],
     "name:hbs_x_preferred":[
         "Abu Dabi"
     ],
@@ -221,6 +242,9 @@
     ],
     "name:hyw_x_preferred":[
         "\u0531\u057a\u0578\u0582 \u054f\u0561\u057a\u056b"
+    ],
+    "name:ibo_x_preferred":[
+        "Abu Dhabi"
     ],
     "name:ido_x_preferred":[
         "Abu Dhabi"
@@ -282,6 +306,9 @@
     "name:lav_x_preferred":[
         "Ab\u016b Dab\u012b"
     ],
+    "name:lfn_x_preferred":[
+        "Abu Dabi"
+    ],
     "name:lij_x_preferred":[
         "Abu Dhabi"
     ],
@@ -312,8 +339,17 @@
     "name:mar_x_preferred":[
         "\u0905\u092c\u0941 \u0927\u093e\u092c\u0940"
     ],
+    "name:min_x_preferred":[
+        "Abu Dhabi"
+    ],
     "name:mkd_x_preferred":[
         "\u0410\u0431\u0443 \u0414\u0430\u0431\u0438"
+    ],
+    "name:mlt_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd1\uabd5\uabe8 \uabd7\uabe5\uabd5\uabe4"
     ],
     "name:mon_x_preferred":[
         "\u0410\u0431\u0443-\u0414\u0430\u0431\u0438 \u0445\u043e\u0442"
@@ -321,6 +357,9 @@
     "name:mon_x_variant":[
         "\u0410\u0431\u0443 \u0414\u0430\u0431\u0438",
         "\u0410\u0431\u0443-\u0414\u0430\u0431\u0438"
+    ],
+    "name:mri_x_preferred":[
+        "\u0100pu T\u0101pi"
     ],
     "name:msa_x_preferred":[
         "Abu Dhabi"
@@ -360,6 +399,9 @@
     ],
     "name:oci_x_preferred":[
         "Abu Dhabi"
+    ],
+    "name:olo_x_preferred":[
+        "Abu-Dabi"
     ],
     "name:ori_x_preferred":[
         "\u0b06\u0b2c\u0b41\u0b27\u0b3e\u0b2c\u0b3f"
@@ -406,6 +448,9 @@
     "name:sah_x_preferred":[
         "\u0410\u0431\u0443 \u0414\u0430\u0431\u0438"
     ],
+    "name:sat_x_preferred":[
+        "\u1c5f\u1c75\u1c69 \u1c6b\u1c77\u1c5f\u1c75\u1c64"
+    ],
     "name:scn_x_preferred":[
         "Abu Dhabi"
     ],
@@ -424,6 +469,15 @@
     "name:slv_x_preferred":[
         "Abu Dabi"
     ],
+    "name:sme_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:smn_x_preferred":[
+        "Abu Dhabi"
+    ],
+    "name:sms_x_preferred":[
+        "Abu Dhabi"
+    ],
     "name:sna_x_preferred":[
         "Abu Dhabi"
     ],
@@ -433,11 +487,17 @@
     "name:spa_x_preferred":[
         "Abu Dabi"
     ],
+    "name:spa_x_variant":[
+        "Abu Dhabi"
+    ],
     "name:sqi_x_preferred":[
         "Ebu Dhabi"
     ],
     "name:sqi_x_variant":[
         "Abu Dabi"
+    ],
+    "name:srd_x_preferred":[
+        "Abu Dhabi"
     ],
     "name:srp_x_preferred":[
         "\u0410\u0431\u0443 \u0414\u0430\u0431\u0438"
@@ -447,6 +507,9 @@
     ],
     "name:swe_x_preferred":[
         "Abu Dhabi"
+    ],
+    "name:szl_x_preferred":[
+        "Abu Zabi"
     ],
     "name:tam_x_preferred":[
         "\u0b85\u0baa\u0bc1\u0ba4\u0bbe\u0baa\u0bbf"
@@ -481,6 +544,12 @@
     "name:tur_x_preferred":[
         "Abu Dabi"
     ],
+    "name:udm_x_preferred":[
+        "\u0410\u0431\u0443-\u0414\u0430\u0431\u0438"
+    ],
+    "name:uig_x_preferred":[
+        "\u0626\u06d5\u0628\u06c7 \u0632\u06d5\u0628\u0649"
+    ],
     "name:ukr_x_preferred":[
         "\u0410\u0431\u0443-\u0414\u0430\u0431\u0456"
     ],
@@ -491,7 +560,8 @@
         "\u0627\u0628\u0648\u0638\u0628\u06cc"
     ],
     "name:urd_x_variant":[
-        "\u0627\u0628\u0648\u0638\u06c1\u0628\u06cc"
+        "\u0627\u0628\u0648\u0638\u06c1\u0628\u06cc",
+        "\u0627\u0628\u0648 \u0638\u06c1\u0628\u06cc"
     ],
     "name:uzb_x_preferred":[
         "Abu-Dabi"
@@ -519,6 +589,9 @@
     ],
     "name:xmf_x_preferred":[
         "\u10d0\u10d1\u10e3-\u10d3\u10d0\u10d1\u10d8"
+    ],
+    "name:yid_x_preferred":[
+        "\u05d0\u05d1\u05d5 \u05d3\u05d0\u05d1\u05d9"
     ],
     "name:yor_x_preferred":[
         "Abu Dhabi"
@@ -682,7 +755,7 @@
         }
     ],
     "wof:id":421179641,
-    "wof:lastmodified":1663974539,
+    "wof:lastmodified":1690848524,
     "wof:name":"Abu Dhabi",
     "wof:parent_id":421172075,
     "wof:placetype":"locality",

--- a/data/421/182/395/421182395.geojson
+++ b/data/421/182/395/421182395.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0628\u062f\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0628\u062f\u064a\u0647"
+    ],
+    "name:ben_x_preferred":[
+        "\u0986\u09b2 \u09ac\u09be\u09a6\u09bf\u09af\u09bc\u09be\u09b9"
+    ],
     "name:cat_x_preferred":[
         "Al-Bidya"
     ],
@@ -40,6 +46,9 @@
     ],
     "name:und_x_variant":[
         "Badiyyah"
+    ],
+    "name:uzb_x_preferred":[
+        "Al Badiyah"
     ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPL",
@@ -87,7 +96,7 @@
         }
     ],
     "wof:id":421182395,
-    "wof:lastmodified":1566581605,
+    "wof:lastmodified":1690848524,
     "wof:name":"\u0627\u0644\u0628\u062f\u064a\u0629",
     "wof:parent_id":1376833611,
     "wof:placetype":"locality",

--- a/data/421/182/517/421182517.geojson
+++ b/data/421/182/517/421182517.geojson
@@ -21,6 +21,12 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0631\u0648\u064a\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0631\u0648\u064a\u0633"
+    ],
+    "name:cat_x_preferred":[
+        "Ruwais"
+    ],
     "name:ceb_x_preferred":[
         "Ar Ruways"
     ],
@@ -32,6 +38,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0631\u0648\u06cc\u0633"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d31\u0d41\u0d35\u0d48\u0d38\u0d4d"
     ],
     "name:nld_x_preferred":[
         "Ruwais"
@@ -54,6 +63,12 @@
     "name:rus_x_preferred":[
         "\u0410\u0440-\u0420\u0443\u0432\u0430\u0438\u0441"
     ],
+    "name:rus_x_variant":[
+        "\u042d\u0440-\u0420\u0443\u0432\u0430\u0439\u0441"
+    ],
+    "name:spa_x_preferred":[
+        "Ruwais"
+    ],
     "name:swe_x_preferred":[
         "Ar Ruways"
     ],
@@ -62,6 +77,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0627\u0644\u0631\u0648\u06cc\u0633"
+    ],
+    "name:zho_x_preferred":[
+        "\u9c81\u74e6\u65af"
     ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPL",
@@ -120,7 +138,7 @@
         }
     ],
     "wof:id":421182517,
-    "wof:lastmodified":1663974539,
+    "wof:lastmodified":1690848524,
     "wof:name":"Ar Ruways",
     "wof:parent_id":1376826403,
     "wof:placetype":"locality",

--- a/data/421/183/109/421183109.geojson
+++ b/data/421/183/109/421183109.geojson
@@ -29,6 +29,9 @@
     "name:eng_x_variant":[
         "Al Twar"
     ],
+    "name:epo_x_preferred":[
+        "Alt\u016dar"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0637\u0648\u0627\u0631"
     ],
@@ -37,6 +40,12 @@
     ],
     "name:ita_x_preferred":[
         "Al Twar"
+    ],
+    "name:nld_x_preferred":[
+        "Al Twar"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0637\u0648\u0627\u0631"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -96,7 +105,7 @@
         }
     ],
     "wof:id":421183109,
-    "wof:lastmodified":1663974539,
+    "wof:lastmodified":1690848523,
     "wof:name":"Al Twar 2",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/183/741/421183741.geojson
+++ b/data/421/183/741/421183741.geojson
@@ -25,6 +25,9 @@
         "Dib\u0101",
         "\u062f\u0628\u0627 \u0627\u0644\u062d\u0635\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0628\u0627 \u0627\u0644\u062d\u0635\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u062f\u0628\u0627 \u0627\u0644\u062d\u0635\u0646 \u0627\u06cc\u0633\u062a\u0627\u062f\u06cc\u0648\u0645\u0648"
     ],
@@ -72,6 +75,9 @@
     ],
     "name:tgl_x_preferred":[
         "Dibba"
+    ],
+    "name:tur_x_preferred":[
+        "Dibba\u00fc'l-Hisn"
     ],
     "name:und_x_variant":[
         "Dibah"
@@ -126,7 +132,7 @@
         }
     ],
     "wof:id":421183741,
-    "wof:lastmodified":1663973422,
+    "wof:lastmodified":1690848523,
     "wof:name":"\u062f\u0628\u0627 \u0627\u0644\u0628\u064a\u0639\u0647",
     "wof:parent_id":1376826387,
     "wof:placetype":"locality",

--- a/data/421/184/571/421184571.geojson
+++ b/data/421/184/571/421184571.geojson
@@ -38,6 +38,12 @@
     "name:ita_x_preferred":[
         "Ayal Nasir"
     ],
+    "name:nld_x_preferred":[
+        "Ayal Nasir"
+    ],
+    "name:urd_x_preferred":[
+        "\u0639\u06cc\u0627\u0644 \u0646\u0627\u0635\u0631"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":8226589,
@@ -95,7 +101,7 @@
         }
     ],
     "wof:id":421184571,
-    "wof:lastmodified":1663974538,
+    "wof:lastmodified":1690848523,
     "wof:name":"Ayal Nasir",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/187/069/421187069.geojson
+++ b/data/421/187/069/421187069.geojson
@@ -27,6 +27,12 @@
         "\u062e\u0648\u0631\u0641\u0643\u0627\u0646",
         "\u0645\u062f\u064a\u0646\u0629 \u062e\u0648\u0631 \u0641\u0643\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u062e\u0648\u0631\u0641\u0643\u0627\u0646"
+    ],
+    "name:ben_x_preferred":[
+        "\u0996\u09cb\u09b0 \u09ab\u09be\u0995\u09cd\u0995\u09be\u09a8"
+    ],
     "name:cat_x_preferred":[
         "Khor Fakkan"
     ],
@@ -35,6 +41,9 @@
     ],
     "name:ces_x_preferred":[
         "Ch\u00f3r Fakk\u00e1n"
+    ],
+    "name:dan_x_preferred":[
+        "Khor Fakkan"
     ],
     "name:deu_x_preferred":[
         "Chaur Fakkan"
@@ -57,6 +66,9 @@
     "name:hye_x_preferred":[
         "\u053d\u0578\u0580-\u0556\u0561\u056f\u056f\u0561\u0576"
     ],
+    "name:ind_x_preferred":[
+        "Khor Fakkan"
+    ],
     "name:ita_x_preferred":[
         "Khawr Fakk\u0101n"
     ],
@@ -65,6 +77,9 @@
     ],
     "name:lit_x_preferred":[
         "Chor Fakanas"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d16\u0d4b\u0d30\u0d4d\u200d\u0d2b\u0d15\u0d4d\u0d15\u0d3e\u0d28\u0d4d\u200d"
     ],
     "name:mkd_x_preferred":[
         "\u0425\u0430\u0443\u0440 \u0435\u043b \u0424\u0430\u043a\u0430\u043d"
@@ -105,6 +120,12 @@
     ],
     "name:tgl_x_preferred":[
         "Khawr Fakkan"
+    ],
+    "name:tur_x_preferred":[
+        "Havr Fakkan"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0425\u043e\u0440-\u0424\u0430\u043a\u043a\u0430\u043d"
     ],
     "name:und_x_variant":[
         "Khor al Fakkan"
@@ -176,7 +197,7 @@
         }
     ],
     "wof:id":421187069,
-    "wof:lastmodified":1663974537,
+    "wof:lastmodified":1690848522,
     "wof:name":"Khor Fakkan",
     "wof:parent_id":421182269,
     "wof:placetype":"locality",

--- a/data/421/188/289/421188289.geojson
+++ b/data/421/188/289/421188289.geojson
@@ -25,6 +25,9 @@
     "name:eng_x_preferred":[
         "Al Mizhar"
     ],
+    "name:epo_x_preferred":[
+        "Almizhar"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0645\u0632\u0647\u0631"
     ],
@@ -33,6 +36,12 @@
     ],
     "name:ita_x_preferred":[
         "Al Mizhar"
+    ],
+    "name:nld_x_preferred":[
+        "Al Mizhar"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0645\u0632\u06c1\u0631"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -57,11 +66,11 @@
     "wd:longitude":55.442,
     "wd:wordcount":92,
     "wof:belongsto":[
+        85667983,
         102191569,
         85632573,
         421174961,
-        1376833603,
-        85667983
+        1376833603
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -83,7 +92,7 @@
         }
     ],
     "wof:id":421188289,
-    "wof:lastmodified":1663973903,
+    "wof:lastmodified":1690848522,
     "wof:name":"Al Mizhar 2",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/188/585/421188585.geojson
+++ b/data/421/188/585/421188585.geojson
@@ -23,6 +23,9 @@
     "name:eng_x_preferred":[
         "Al Baraha"
     ],
+    "name:epo_x_preferred":[
+        "Albaraha"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0628\u0631\u0627\u062d\u0629"
     ],
@@ -35,8 +38,14 @@
     "name:ita_x_preferred":[
         "Al Baraha"
     ],
+    "name:nld_x_preferred":[
+        "Al Baraha"
+    ],
     "name:und_x_variant":[
         "Bar\u0101\u1e29ah"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0628\u0631\u0627\u062d\u06c1"
     ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":421188585,
-    "wof:lastmodified":1663974538,
+    "wof:lastmodified":1690848522,
     "wof:name":"Al Baraha",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/188/805/421188805.geojson
+++ b/data/421/188/805/421188805.geojson
@@ -23,6 +23,9 @@
     "name:eng_x_preferred":[
         "Al Kifaf"
     ],
+    "name:epo_x_preferred":[
+        "Alkefaf"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u06a9\u0641\u0627\u0641"
     ],
@@ -31,6 +34,12 @@
     ],
     "name:ita_x_preferred":[
         "Al Kifaf"
+    ],
+    "name:nld_x_preferred":[
+        "Al Kifaf"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u06a9\u0641\u0627\u0641"
     ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
@@ -91,7 +100,7 @@
         }
     ],
     "wof:id":421188805,
-    "wof:lastmodified":1663974537,
+    "wof:lastmodified":1690848522,
     "wof:name":"Al Kifaf",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/192/859/421192859.geojson
+++ b/data/421/192/859/421192859.geojson
@@ -35,8 +35,14 @@
     "name:ita_x_preferred":[
         "Al Muraqqabat"
     ],
+    "name:nld_x_preferred":[
+        "Al Muraqqabat"
+    ],
     "name:und_x_variant":[
         "Al Muraqqab\u0101t"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0645\u0631\u0642\u0628\u0627\u062a"
     ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
@@ -95,7 +101,7 @@
         }
     ],
     "wof:id":421192859,
-    "wof:lastmodified":1663974536,
+    "wof:lastmodified":1690848520,
     "wof:name":"Al Muraqqabat",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/421/192/959/421192959.geojson
+++ b/data/421/192/959/421192959.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0630\u064a\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0630\u064a\u062f"
+    ],
     "name:cat_x_preferred":[
         "Dhaid"
     ],
@@ -35,6 +38,12 @@
     "name:fas_x_preferred":[
         "\u0630\u06cc\u062f"
     ],
+    "name:ita_x_preferred":[
+        "Dhaid"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d26\u0d48\u0d26\u0d4d"
+    ],
     "name:nld_x_preferred":[
         "Dhaid"
     ],
@@ -44,8 +53,14 @@
     "name:pol_x_preferred":[
         "Az-Zajd"
     ],
+    "name:rus_x_preferred":[
+        "\u042d\u0434-\u0414\u0430\u0439\u0434"
+    ],
     "name:swe_x_preferred":[
         "Adh Dhayd"
+    ],
+    "name:tur_x_preferred":[
+        "Zeyd"
     ],
     "name:urd_x_preferred":[
         "\u0630\u06cc\u062f"
@@ -110,7 +125,7 @@
         }
     ],
     "wof:id":421192959,
-    "wof:lastmodified":1663974537,
+    "wof:lastmodified":1690848520,
     "wof:name":"\u0627\u0644\u0630\u064a\u062f",
     "wof:parent_id":421176643,
     "wof:placetype":"locality",

--- a/data/421/193/341/421193341.geojson
+++ b/data/421/193/341/421193341.geojson
@@ -38,6 +38,12 @@
     "name:ita_x_preferred":[
         "Al Mizhar"
     ],
+    "name:nld_x_preferred":[
+        "Al Mizhar"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0645\u0632\u06c1\u0631"
+    ],
     "qs:gn_country":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":8200820,
@@ -98,7 +104,7 @@
         }
     ],
     "wof:id":421193341,
-    "wof:lastmodified":1663974537,
+    "wof:lastmodified":1690848521,
     "wof:name":"Al Mizhar",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/856/325/73/85632573.geojson
+++ b/data/856/325/73/85632573.geojson
@@ -33,6 +33,9 @@
     "mz:is_current":1,
     "mz:max_zoom":9.0,
     "mz:min_zoom":4.0,
+    "name:abk_x_preferred":[
+        "\u0415\u0438\u0434\u0443 \u0410\u0440\u0430\u0431\u0442\u04d9 \u0415\u043c\u0438\u0440\u0430\u0442\u049b\u04d9\u0430"
+    ],
     "name:ace_x_preferred":[
         "Imarat Arab Meusaboh"
     ],
@@ -57,11 +60,17 @@
     "name:amh_x_variant":[
         "\u12e8\u1270\u1263\u1260\u1229\u1275 \u12a0\u1228\u1265 \u12a4\u121d\u122c\u1275\u1235"
     ],
+    "name:ami_x_preferred":[
+        "United arab emirates"
+    ],
     "name:ang_x_preferred":[
         "Ge\u0101nedu Arabisc Bregor\u012bcu"
     ],
     "name:ang_x_variant":[
         "Ge\u0101nedan Arabiscan Bregor\u012bce"
+    ],
+    "name:anp_x_preferred":[
+        "\u0938\u0902\u092f\u0941\u0915\u094d\u0924 \u0905\u0930\u092c \u0905\u092e\u0940\u0930\u093e\u0924"
     ],
     "name:ara_x_preferred":[
         "\u0627\u0644\u0625\u0645\u0627\u0631\u0627\u062a \u0627\u0644\u0639\u0631\u0628\u064a\u0629 \u0627\u0644\u0645\u062a\u062d\u062f\u0629"
@@ -95,6 +104,9 @@
     "name:ava_x_preferred":[
         "\u0413I\u0430\u0440\u0430\u0431\u0430\u0437\u0443\u043b \u0426\u043e\u043b\u044a\u0430\u0440\u0430\u043b \u0418\u043c\u0430\u0440\u0430\u0442\u0430\u043b"
     ],
+    "name:awa_x_preferred":[
+        "\u0938\u0902\u092f\u0941\u0915\u094d\u0924 \u0905\u0930\u092c \u0907\u092e\u093f\u0930\u0947\u091f\u094d\u0938"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u06cc\u0645\u0627\u0631\u0627\u062a"
     ],
@@ -109,6 +121,9 @@
     ],
     "name:bam_x_preferred":[
         "Arabu mara kafoli"
+    ],
+    "name:ban_x_preferred":[
+        "Uni \u00c9mirat Arab"
     ],
     "name:bar_x_preferred":[
         "Vaeinigte Arabische Emirate"
@@ -138,8 +153,14 @@
     "name:bih_x_preferred":[
         "\u092f\u0942\u0928\u093e\u0907\u091f\u0947\u0921 \u0905\u0930\u092c \u0905\u092e\u0940\u0930\u093e\u0924"
     ],
+    "name:bis_x_preferred":[
+        "Yunaeted Arab Emirets"
+    ],
     "name:bjn_x_preferred":[
         "Syarikat Amiriah Arab"
+    ],
+    "name:blk_x_preferred":[
+        "\u1021\u102c\u101b\u1015\u103a\u1005\u101d\u103a\u1038\u1016\u102c\u1038\u1001\u1019\u103a\u1038\u1015\u1031\u102b\u1004\u103a\uaa7b\u1017\u1030\u108f\u1001\u1019\u103a\u1038\u1011\u102e"
     ],
     "name:bod_x_preferred":[
         "\u0f61\u0f72\u0f0b\u0f53\u0f7a\u0f0b\u0f41\u0fb2\u0f7a\u0f0b\u0f40\u0fb2\u0f72\u0f0b\u0f68\u0f0b\u0f62\u0f56\u0f0b\u0f68\u0f7a\u0f0b\u0f58\u0f7a\u0f0b\u0f62\u0f7a\u0f0b\u0f41\u0fb2\u0f72\u0f0d"
@@ -199,6 +220,9 @@
         "I\u0430\u044c\u0440\u0431\u0438\u0439\u043d \u0426\u0445\u044c\u0430\u044c\u043d\u0430\u043a\u0445\u0435\u0442\u0442\u0430 \u042d\u043c\u0438\u0440\u0430\u0442\u0430\u0448",
         "\u04c0\u0430\u044c\u0440\u0431\u0438\u0439\u043d \u0426\u0445\u044c\u0430\u044c\u043d\u0430\u0442\u043e\u044c\u0445\u043d\u0430 \u042d\u043c\u0438\u0440\u0430\u0442\u0430\u0448"
     ],
+    "name:chu_x_preferred":[
+        "\u0464\u0434\u044c\u043d\u0465\u043d\ua651 \u0410\u0440\u0430\u0432\u044c\u0441\u043a\ua651 \u0404\u043c\u0438\u0440\u0430\u0442\ua651"
+    ],
     "name:ckb_x_preferred":[
         "\u0645\u06cc\u0631\u0646\u0634\u06cc\u0646\u06d5 \u06cc\u06d5\u06a9\u06af\u0631\u062a\u0648\u0648\u06d5 \u0639\u06d5\u0631\u06d5\u0628\u06cc\u06cc\u06d5\u06a9\u0627\u0646"
     ],
@@ -216,6 +240,9 @@
     ],
     "name:cym_x_variant":[
         "Emiraethau Arabaidd Unedig"
+    ],
+    "name:dag_x_preferred":[
+        "United Arab Emirates"
     ],
     "name:dan_x_preferred":[
         "Forenede Arabiske Emirater"
@@ -340,6 +367,9 @@
     "name:ful_x_preferred":[
         "Emiraat Araab Denntu\u0257e"
     ],
+    "name:ful_x_variant":[
+        "Imaaraatuuji Aarabe Dentu\u0257i"
+    ],
     "name:gag_x_preferred":[
         "Birle\u015fik Arab Emirlikleri"
     ],
@@ -363,6 +393,9 @@
     ],
     "name:gom_x_preferred":[
         "\u0938\u0902\u092f\u0941\u0915\u094d\u0924 \u0905\u0930\u092c \u0905\u092e\u0940\u0930\u093e\u0924"
+    ],
+    "name:gpe_x_preferred":[
+        "United Arab Emirates"
     ],
     "name:grn_x_preferred":[
         "Aravia Emiryvy Joaju"
@@ -430,6 +463,9 @@
     ],
     "name:hyw_x_preferred":[
         "\u0531\u0580\u0561\u0562\u0561\u056f\u0561\u0576 \u0544\u056b\u0561\u0581\u0565\u0561\u056c \u0537\u0574\u056b\u0580\u0578\u0582\u0569\u056b\u0582\u0576\u0576\u0565\u0580"
+    ],
+    "name:ibo_x_preferred":[
+        "United Arab Emirates"
     ],
     "name:ido_x_preferred":[
         "Unionita Araba Emirati"
@@ -509,6 +545,9 @@
     "name:khm_x_preferred":[
         "\u17a2\u17c1\u1798\u17b8\u179a\u17c9\u17c2\u1791\u17a2\u17b6\u179a\u17c9\u17b6\u1794\u17cb\u179a\u17bd\u1798"
     ],
+    "name:khm_x_variant":[
+        "\u179f\u17a0\u1796\u17d0\u1793\u17d2\u1792\u200b\u17a2\u17b6\u179a\u17c9\u17b6\u1794\u17cb\u179a\u17bd\u1798"
+    ],
     "name:kik_x_preferred":[
         "United Arab Emirates"
     ],
@@ -533,6 +572,9 @@
     "name:kor_x_variant":[
         "\uc544\ub78d\uc5d0\ubbf8\ub9ac\ud2b8\uc5f0\ud569",
         "\uc544\ub78d\uc5d0\ubbf8\ub9ac\ud2b8 \uc5f0\ud569"
+    ],
+    "name:krj_x_preferred":[
+        "manga Emirato Arabe Ting\u00ebb"
     ],
     "name:ksh_x_preferred":[
         "Vereineschte Arrahbesche Emmerahte"
@@ -584,6 +626,9 @@
     "name:lit_x_preferred":[
         "Jungtiniai Arab\u0173 Emyratai"
     ],
+    "name:lld_x_preferred":[
+        "Emirac Arabs Unii"
+    ],
     "name:lmo_x_preferred":[
         "Emiraa Arab \u00dcnii"
     ],
@@ -597,6 +642,9 @@
     "name:ltz_x_preferred":[
         "Vereenegt Arabesch Emiraten"
     ],
+    "name:ltz_x_variant":[
+        "Vereenegt Arabesch Emirater"
+    ],
     "name:lub_x_preferred":[
         "Lemila alabu"
     ],
@@ -605,6 +653,9 @@
     ],
     "name:lzh_x_preferred":[
         "\u963f\u62c9\u4f2f\u806f\u5408\u914b\u9577\u570b"
+    ],
+    "name:mad_x_preferred":[
+        "Uni Emirat Arab"
     ],
     "name:mai_x_preferred":[
         "\u092f\u0941\u0928\u093e\u0907\u091f\u0947\u0921 \u0905\u0930\u092c \u0907\u092e\u093f\u0930\u0947\u091f\u094d\u0938"
@@ -624,6 +675,15 @@
     "name:mar_x_variant":[
         "\u0938\u0902\u092f\u0941\u0915\u094d\u0924 \u0905\u0930\u092c \u0905\u092e\u0940\u0930\u093e\u0924"
     ],
+    "name:mdf_x_preferred":[
+        "\u0421\u043e\u0442\u043a\u0441 \u0410\u0440\u0430\u0431\u043e\u043d\u044c \u042d\u043c\u0438\u0440\u0430\u0442\u043d\u0435"
+    ],
+    "name:mhr_x_preferred":[
+        "\u0423\u0448\u043d\u044b\u0448\u043e \u0410\u0440\u0430\u0431 \u042d\u043c\u0438\u0440\u0430\u0442"
+    ],
+    "name:min_x_preferred":[
+        "Uni Emirat Arab"
+    ],
     "name:mkd_x_preferred":[
         "\u041e\u0431\u0435\u0434\u0438\u043d\u0435\u0442\u0438 \u0410\u0440\u0430\u043f\u0441\u043a\u0438 \u0415\u043c\u0438\u0440\u0430\u0442\u0438"
     ],
@@ -639,11 +699,17 @@
     "name:mlt_x_variant":[
         "Emirati G\u0127arab Maqg\u0127uda"
     ],
+    "name:mni_x_preferred":[
+        "\uabd1\uabc4\uabe8\uabdf\uabd5 \uabd1\uabe5\uabd4\uabd5 \uabd1\uabe6\uabc3\uabe4\uabd4\uabe6\uabe0\uabc1\uabe4\uabe1"
+    ],
     "name:mon_x_preferred":[
         "\u0410\u0440\u0430\u0431\u044b\u043d \u041d\u044d\u0433\u0434\u0441\u044d\u043d \u042d\u043c\u0438\u0440\u0442 \u0423\u043b\u0441"
     ],
     "name:msa_x_preferred":[
         "Emiriah Arab Bersatu"
+    ],
+    "name:mwl_x_preferred":[
+        "Eimirados \u00c1rabes Ounidos"
     ],
     "name:mya_x_preferred":[
         "\u1021\u102c\u101b\u1015\u103a\u1005\u1031\u102c\u103a\u1018\u103d\u102c\u1038\u1019\u103b\u102c\u1038\u1015\u103c\u100a\u103a\u1011\u1031\u102c\u1004\u103a\u1005\u102f\u1014\u102d\u102f\u1004\u103a\u1004\u1036"
@@ -651,6 +717,9 @@
     "name:mya_x_variant":[
         "\u101a\u1030\u1021\u1031\u1021\u102e\u1038",
         "\u1021\u102c\u101b\u1015\u103a\u1005\u1031\u102c\u103a\u1018\u103d\u102c\u1038\u1019\u103b\u102c\u1038\u1015\u103c\u100a\u103a\u1011\u1031\u102c\u1004\u103a\u1005\u102f"
+    ],
+    "name:myv_x_preferred":[
+        "\u0412\u0435\u0439\u0441\u044d\u043d\u0434\u044f\u0437\u044c \u0410\u0440\u0430\u0431\u043e\u043d\u044c \u042d\u043c\u0438\u0440\u0430\u0442\u0442\u043d\u044d"
     ],
     "name:mzn_x_preferred":[
         "\u0645\u062a\u062d\u062f\u0647 \u0639\u0631\u0628\u06cc \u0627\u0645\u0627\u0631\u0627\u062a"
@@ -700,6 +769,9 @@
     ],
     "name:nov_x_preferred":[
         "Unionati Arabi Emirates"
+    ],
+    "name:nya_x_preferred":[
+        "United Arab Emirates"
     ],
     "name:oci_x_preferred":[
         "Emirats Arabis Units"
@@ -799,6 +871,12 @@
     "name:sah_x_variant":[
         "\u0425\u043e\u043b\u0431\u043eh\u0443\u043a\u0442\u0430\u0430\u0445 \u0410\u0440\u0430\u0430\u0431 \u042d\u043c\u0438\u0440\u0430\u0442\u0442\u0430\u0440\u0430"
     ],
+    "name:san_x_preferred":[
+        "\u0938\u0902\u092f\u0941\u0915\u094d\u0924 \u0905\u0930\u092c \u0905\u092e\u0940\u0930\u093f\u092f\u0930\u093e\u091c\u094d\u092f\u093e\u0928\u093f"
+    ],
+    "name:sat_x_preferred":[
+        "\u1c65\u1c6e\u1c5e\u1c6e\u1c6b \u1c5f\u1c68\u1c5a\u1c75\u1c7d \u1c5f\u1c62\u1c64\u1c68\u1c5f\u1c5b"
+    ],
     "name:scn_x_preferred":[
         "Emirati \u00c0rabbi Uniti"
     ],
@@ -807,6 +885,9 @@
     ],
     "name:sgs_x_preferred":[
         "Jongt\u0117n\u0113 Arabu Em\u012brat\u0101"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1081\u1030\u1019\u103a\u1088\u1010\u102f\u1019\u103a \u1078\u101d\u103a\u1088\u107e\u1083\u1089 \u1022\u1083\u1087\u101b\u1062\u1015\u103a\u1088"
     ],
     "name:sin_x_preferred":[
         "\u0d91\u0d9a\u0dca\u0dc3\u0dad\u0dca \u0d85\u0dbb\u0dcf\u0db6\u0dd2 \u0d91\u0db8\u0dd3\u0dbb\u0dca \u0dbb\u0dcf\u0da2\u0dca\u200d\u0dba\u0dba"
@@ -826,8 +907,14 @@
     "name:sme_x_variant":[
         "Ovttastuvvan Ar\u00e1baemir\u00e1htat"
     ],
+    "name:smn_x_preferred":[
+        "Ovt\u00e2stum arabiemiirikodeh"
+    ],
     "name:smo_x_preferred":[
         "Malo Alapi Lotogatasi"
+    ],
+    "name:sms_x_preferred":[
+        "\u00d5htt\u00f5\u00f5vv\u00e2m araabemiirk\u00e5\u00e5\u02b9dd"
     ],
     "name:sna_x_preferred":[
         "United Arab Emirates"
@@ -890,6 +977,9 @@
     "name:swe_x_preferred":[
         "F\u00f6renade Arabemiraten"
     ],
+    "name:swe_x_variant":[
+        "F\u00f6renade arabemiraten"
+    ],
     "name:szl_x_preferred":[
         "Zjednocz\u016fne Arabske Ymiraty"
     ],
@@ -904,6 +994,9 @@
     ],
     "name:tat_x_preferred":[
         "\u0411\u0435\u0440\u043b\u04d9\u0448\u043a\u04d9\u043d \u0413\u0430\u0440\u04d9\u043f \u04d8\u043c\u0438\u0440\u043b\u0435\u043a\u043b\u04d9\u0440\u0435"
+    ],
+    "name:tay_x_preferred":[
+        "United arab emirates"
     ],
     "name:tel_x_preferred":[
         "\u0c2f\u0c41\u0c28\u0c48\u0c1f\u0c46\u0c21\u0c4d \u0c05\u0c30\u0c2c\u0c4d \u0c0e\u0c2e\u0c3f\u0c30\u0c47\u0c1f\u0c4d\u0c38\u0c4d"
@@ -939,6 +1032,9 @@
     "name:tpi_x_preferred":[
         "United Arab Emirates"
     ],
+    "name:trv_x_preferred":[
+        "United Arab Emirates"
+    ],
     "name:tuk_x_preferred":[
         "Birle\u015fen Arap Emirlikleri"
     ],
@@ -953,6 +1049,9 @@
     ],
     "name:uig_x_preferred":[
         "\u0626\u06d5\u0631\u06d5\u0628 \u0628\u0649\u0631\u0644\u06d5\u0634\u0645\u06d5 \u062e\u06d5\u0644\u0649\u067e\u0649\u0644\u0649\u0643\u0649"
+    ],
+    "name:uig_x_variant":[
+        "\u0628\u0649\u0631\u0644\u06d5\u0634\u0645\u06d5 \u0626\u06d5\u0631\u06d5\u0628 \u0626\u06d5\u0645\u0649\u0631\u0644\u0649\u0643\u0644\u0649\u0631\u0649"
     ],
     "name:ukr_x_preferred":[
         "\u041e\u0431'\u0454\u0434\u043d\u0430\u043d\u0456 \u0410\u0440\u0430\u0431\u0441\u044c\u043a\u0456 \u0415\u043c\u0456\u0440\u0430\u0442\u0438"
@@ -988,6 +1087,9 @@
     ],
     "name:vol_x_preferred":[
         "Lemir\u00e4ns Larabik Pebal\u00f6l"
+    ],
+    "name:vol_x_variant":[
+        "Lemir\u00e4ns Larabik Pebal\u00f6ls"
     ],
     "name:vro_x_preferred":[
         "Araabia \u00dctisemiraadiq"
@@ -1268,7 +1370,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1663974531,
+    "wof:lastmodified":1690848514,
     "wof:name":"United Arab Emirates",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/679/51/85667951.geojson
+++ b/data/856/679/51/85667951.geojson
@@ -45,6 +45,9 @@
     "name:ara_x_variant":[
         "\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629"
+    ],
     "name:bel_x_preferred":[
         "\u042d\u043c\u0456\u0440\u0430\u0442 \u0420\u0430\u0441-\u044d\u043b\u044c-\u0425\u0430\u0439\u043c\u0430"
     ],
@@ -53,6 +56,12 @@
     ],
     "name:ben_x_preferred":[
         "\u09b0\u09be\u09b8 \u0986\u09b2-\u0996\u09be\u0987\u09ae\u09be\u09b9"
+    ],
+    "name:ben_x_variant":[
+        "\u09b0\u09be\u09b8 \u0986\u09b2 \u0996\u09be\u0987\u09ae\u09be\u09b9 \u0986\u09ae\u09bf\u09b0\u09be\u09a4"
+    ],
+    "name:bos_x_preferred":[
+        "Ras al-Khaimah"
     ],
     "name:bre_x_preferred":[
         "Ras al-Khaimah"
@@ -75,11 +84,17 @@
     "name:dan_x_preferred":[
         "Ras al-Khaimah"
     ],
+    "name:dan_x_variant":[
+        "Emiratet Ras al-Khaimah"
+    ],
     "name:deu_x_preferred":[
         "Ra\u2019s al-Chaima"
     ],
     "name:ell_x_preferred":[
         "\u03a1\u03b1\u03c2 \u03b1\u03bb-\u039a\u03b1\u03ca\u03bc\u03ac"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03bc\u03b9\u03c1\u03ac\u03c4\u03bf \u03c4\u03bf\u03c5 \u03a1\u03b1\u03c2 \u03b1\u03bb-\u03a7\u03b1\u03ca\u03bc\u03ac"
     ],
     "name:eng_x_preferred":[
         "Ras al Khaimah"
@@ -87,10 +102,14 @@
     "name:eng_x_variant":[
         "Ra's al Khaymah",
         "Ras al Khaymah",
-        "Ras al-Khaimah"
+        "Ras al-Khaimah",
+        "Emirate of Ras Al Khaimah"
     ],
     "name:epo_x_preferred":[
         "Ras-al-\u0124ajmo"
+    ],
+    "name:epo_x_variant":[
+        "Rasal\u0125ajmo"
     ],
     "name:est_x_preferred":[
         "Ra's al-Khaymah' emiraat"
@@ -106,6 +125,9 @@
     ],
     "name:fra_x_preferred":[
         "Ras el Kha\u00efmah"
+    ],
+    "name:glg_x_preferred":[
+        "Ras al-Jaimah"
     ],
     "name:guj_x_preferred":[
         "\u0ab0\u0abe\u0ab8 \u0a85\u0ab2-\u0a96\u0ac8\u0aae\u0abe\u0ab9"
@@ -138,8 +160,14 @@
         "\u054c\u0561\u057d-\u0561\u056c-\u053d\u0561\u0575\u0574\u0561\u0575\u056b \u0567\u0574\u056b\u0580\u0578\u0582\u0569\u0575\u0578\u0582\u0576",
         "\u054c\u0561\u057d \u0561\u056c-\u053d\u0561\u0575\u0574\u0561\u0575\u056b \u0537\u0574\u056b\u0580\u0578\u0582\u0569\u0575\u0578\u0582\u0576"
     ],
+    "name:hyw_x_preferred":[
+        "\u054c\u0561\u057d \u0561\u056c \u053d\u0561\u0575\u0574\u0561"
+    ],
     "name:ind_x_preferred":[
         "Ras al-Khaimah"
+    ],
+    "name:isl_x_preferred":[
+        "Ras al-Ka\u00edma"
     ],
     "name:ita_x_preferred":[
         "Ras al-Khaima"
@@ -179,6 +207,9 @@
     ],
     "name:msa_x_preferred":[
         "Ras al-Khaimah"
+    ],
+    "name:msa_x_variant":[
+        "Emiriah Ras al-Khaimah"
     ],
     "name:nan_x_preferred":[
         "Ras al-Khaimah"
@@ -264,11 +295,17 @@
     "name:tel_x_preferred":[
         "\u0c30\u0c3e\u0c38\u0c4d \u0c05\u0c32\u0c4d-\u0c16\u0c48\u0c2e\u0c3e"
     ],
+    "name:tgk_x_preferred":[
+        "\u0420\u0430\u044a\u0441\u0443-\u043b-\u0425\u0430\u0439\u043c\u0430"
+    ],
     "name:tgl_x_preferred":[
         "Ras al-Khaimah"
     ],
     "name:tha_x_preferred":[
         "\u0e23\u0e31\u0e10\u0e23\u0e32\u0e2a\u0e2d\u0e31\u0e25\u0e44\u0e04\u0e21\u0e32\u0e2b\u0e4c"
+    ],
+    "name:tha_x_variant":[
+        "\u0e23\u0e31\u0e10\u0e40\u0e23\u0e32\u0e30\u0e0b\u0e38\u0e25\u0e04\u0e31\u0e22\u0e21\u0e30\u0e2e\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Res\u00fc'l-Hayme"
@@ -291,6 +328,9 @@
     "name:war_x_preferred":[
         "Ras al-Kaimah"
     ],
+    "name:wuu_x_preferred":[
+        "\u54c8\u4f0a\u9a6c\u89d2\u914b\u957f\u56fd"
+    ],
     "name:xmf_x_preferred":[
         "\u10e0\u10d0\u10e1-\u10d4\u10da-\u10ee\u10d0\u10d8\u10db\u10d0\u10e8 \u10e1\u10d0\u10d0\u10db\u10d8\u10e0\u10dd"
     ],
@@ -302,6 +342,9 @@
     ],
     "name:zho_x_preferred":[
         "\u62c9\u65af\u6d77\u739b"
+    ],
+    "name:zho_x_variant":[
+        "\u62c9\u65af\u6d77\u746a\u914b\u9577\u570b"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ARE",
@@ -434,7 +477,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1663974532,
+    "wof:lastmodified":1690848516,
     "wof:name":"Ras Al Khaimah",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/55/85667955.geojson
+++ b/data/856/679/55/85667955.geojson
@@ -46,6 +46,9 @@
     "name:ast_x_preferred":[
         "Emiratu d'Umm al-Qaywayn"
     ],
+    "name:aze_x_preferred":[
+        "\u00dcmm \u0259l-Qeyveyn \u0259mirliyi"
+    ],
     "name:bel_x_preferred":[
         "\u042d\u043c\u0456\u0440\u0430\u0442 \u0423\u043c-\u044d\u043b\u044c-\u041a\u0430\u0439\u0432\u0430\u0439\u043d"
     ],
@@ -54,6 +57,12 @@
     ],
     "name:ben_x_preferred":[
         "\u0989\u09ae\u09cd\u09ae\u09c1\u09b2 \u0995\u09c1\u09af\u09bc\u09be\u0987\u09a8"
+    ],
+    "name:ben_x_variant":[
+        "\u0989\u09ae\u09cd\u09ae \u0986\u09b2 \u0995\u09cb\u09af\u09bc\u09be\u0987\u09a8 \u0986\u09ae\u09bf\u09b0\u09be\u09a4"
+    ],
+    "name:bos_x_preferred":[
+        "Umm al-Quwain"
     ],
     "name:bre_x_preferred":[
         "Umm al-Qaywayn"
@@ -73,6 +82,9 @@
     "name:dan_x_preferred":[
         "Umm Al Quwain"
     ],
+    "name:dan_x_variant":[
+        "Emiratet Umm Al Quwain"
+    ],
     "name:deu_x_preferred":[
         "Umm al-Qaiwain"
     ],
@@ -84,10 +96,14 @@
     ],
     "name:eng_x_variant":[
         "Umm al Qaywayn",
-        "Umm al-Quwain"
+        "Umm al-Quwain",
+        "Emirate of Umm Al Quwain"
     ],
     "name:epo_x_preferred":[
         "Um-al-Kajvajno"
+    ],
+    "name:epo_x_variant":[
+        "Umalkajvajno"
     ],
     "name:est_x_preferred":[
         "Umm al-Qaywayni emiraat"
@@ -260,6 +276,9 @@
     "name:tha_x_preferred":[
         "\u0e23\u0e31\u0e10\u0e2d\u0e38\u0e21\u0e21\u0e4c\u0e2d\u0e31\u0e25\u0e44\u0e01\u0e44\u0e27\u0e19\u0e4c"
     ],
+    "name:tha_x_variant":[
+        "\u0e23\u0e31\u0e10\u0e2d\u0e38\u0e21\u0e21\u0e4c\u0e2d\u0e31\u0e25\u0e01\u0e38\u0e40\u0e27\u0e19"
+    ],
     "name:tur_x_preferred":[
         "Umm\u00fcl-Kayveyn Emirli\u011fi"
     ],
@@ -275,6 +294,12 @@
     "name:vie_x_preferred":[
         "Umm al-Quwain"
     ],
+    "name:war_x_preferred":[
+        "Emirato han Umm Al Quwain"
+    ],
+    "name:wuu_x_preferred":[
+        "\u4e4c\u59c6\u76d6\u4e07\u914b\u957f\u56fd"
+    ],
     "name:xmf_x_preferred":[
         "\u10e3\u10db-\u10d4\u10da-\u10e5\u10d0\u10d8\u10d5\u10d0\u10d8\u10dc\u10d8\u10e8 \u10e1\u10d0\u10d0\u10db\u10d8\u10e0\u10dd"
     ],
@@ -284,11 +309,15 @@
     "name:yue_x_preferred":[
         "\u6b50\u59c6\u53e4\u6eab\u914b\u9577\u570b"
     ],
+    "name:yue_x_variant":[
+        "\u70cf\u59c6\u84cb\u842c\u914b\u9577\u570b"
+    ],
     "name:zho_x_preferred":[
         "\u70cf\u59c6\u84cb\u842c"
     ],
     "name:zho_x_variant":[
-        "\u6b27\u59c6\u53e4\u6e29"
+        "\u6b27\u59c6\u53e4\u6e29",
+        "\u4e4c\u59c6\u76d6\u4e07\u914b\u957f\u56fd"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ARE",
@@ -427,7 +456,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1663974532,
+    "wof:lastmodified":1690848516,
     "wof:name":"Umm Al Quwain",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/59/85667959.geojson
+++ b/data/856/679/59/85667959.geojson
@@ -43,8 +43,14 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0641\u062c\u064a\u0631\u0629"
     ],
+    "name:ara_x_variant":[
+        "\u0625\u0645\u0627\u0631\u0629 \u0627\u0644\u0641\u062c\u064a\u0631\u0629"
+    ],
     "name:aze_x_preferred":[
         "\u018fl-F\u00fcceyr\u0259 \u0259mirliyi"
+    ],
+    "name:bak_x_preferred":[
+        "\u04d8\u043b-\u0424\u04af\u0436\u04d9\u0439\u0440\u04d9"
     ],
     "name:bel_x_preferred":[
         "\u042d\u043c\u0456\u0440\u0430\u0442 \u042d\u043b\u044c-\u0424\u0443\u0434\u0436\u0430\u0439\u0440\u0430"
@@ -54,6 +60,12 @@
     ],
     "name:ben_x_preferred":[
         "\u09ab\u09c1\u099c\u09be\u09af\u09bc\u09b0\u09be"
+    ],
+    "name:ben_x_variant":[
+        "\u09ab\u09c1\u099c\u09be\u0987\u09b0\u09be\u09b9 \u0986\u09ae\u09bf\u09b0\u09be\u09a4"
+    ],
+    "name:bos_x_preferred":[
+        "Fujairah"
     ],
     "name:bre_x_preferred":[
         "Fujayrah"
@@ -72,6 +84,9 @@
     ],
     "name:dan_x_preferred":[
         "Fujairah"
+    ],
+    "name:dan_x_variant":[
+        "Emiratet Fujairah"
     ],
     "name:deu_x_preferred":[
         "Fudschaira"
@@ -128,6 +143,9 @@
     "name:ind_x_preferred":[
         "Fujairah"
     ],
+    "name:isl_x_preferred":[
+        "F\u00fadsa\u00edra"
+    ],
     "name:ita_x_preferred":[
         "Fujaira"
     ],
@@ -136,6 +154,9 @@
     ],
     "name:kan_x_preferred":[
         "\u0cab\u0cc1\u0c9c\u0cc8\u0cb0\u0cbe"
+    ],
+    "name:kat_x_preferred":[
+        "\u10d0\u10da-\u10e4\u10e3\u10ef\u10d0\u10d8\u10e0\u10d0\u10e1 \u10e1\u10d0\u10d0\u10db\u10d8\u10e0\u10dd"
     ],
     "name:kor_x_preferred":[
         "\ud478\uc790\uc774\ub77c \ud1a0\ud6c4\uad6d"
@@ -275,6 +296,9 @@
     "name:vie_x_preferred":[
         "Fujairah"
     ],
+    "name:wuu_x_preferred":[
+        "\u5bcc\u67e5\u4f0a\u62c9\u914b\u957f\u56fd"
+    ],
     "name:xmf_x_preferred":[
         "\u10d4\u10da-\u10e4\u10e3\u10ef\u10d0\u10d8\u10e0\u10d0\u10e8 \u10e1\u10d0\u10d0\u10db\u10d8\u10e0\u10dd"
     ],
@@ -286,6 +310,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5bcc\u5409\u62c9"
+    ],
+    "name:zho_x_variant":[
+        "\u5bcc\u67e5\u4f0a\u62c9\u914b\u957f\u56fd"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ARE",
@@ -421,7 +448,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1663974531,
+    "wof:lastmodified":1690848515,
     "wof:name":"Fujairah",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/69/85667969.geojson
+++ b/data/856/679/69/85667969.geojson
@@ -58,6 +58,12 @@
     "name:ben_x_preferred":[
         "\u0986\u099c\u09ae\u09be\u09a8 \u098f\u09ae\u09bf\u09b0\u09be\u09a4"
     ],
+    "name:ben_x_variant":[
+        "\u0986\u099c\u09ae\u09be\u09a8 \u0986\u09ae\u09bf\u09b0\u09be\u09a4"
+    ],
+    "name:bos_x_preferred":[
+        "Ajman"
+    ],
     "name:bre_x_preferred":[
         "Ajman"
     ],
@@ -73,14 +79,23 @@
     "name:ces_x_preferred":[
         "Ad\u017em\u00e1n"
     ],
+    "name:dag_x_preferred":[
+        "Ajman"
+    ],
     "name:dan_x_preferred":[
         "Ajman"
+    ],
+    "name:dan_x_variant":[
+        "Emiratet Ajman"
     ],
     "name:deu_x_preferred":[
         "Adschman"
     ],
     "name:ell_x_preferred":[
         "\u0391\u03ca\u03bc\u03ac\u03bd"
+    ],
+    "name:ell_x_variant":[
+        "\u0391\u03c4\u03b6\u03bc\u03ac\u03bd"
     ],
     "name:eng_x_preferred":[
         "Ajman"
@@ -194,6 +209,9 @@
     "name:nan_x_preferred":[
         "Ajman Th\u00e2u-l\u00e2ng-kok"
     ],
+    "name:nep_x_preferred":[
+        "\u0905\u091c\u092e\u093e\u0928 \u0907\u092e\u093f\u0930\u0947\u091f\u094d\u0938"
+    ],
     "name:nld_x_preferred":[
         "Ajman"
     ],
@@ -272,6 +290,9 @@
     "name:tha_x_preferred":[
         "\u0e23\u0e31\u0e10\u0e2d\u0e31\u0e08\u0e21\u0e32\u0e19"
     ],
+    "name:tha_x_variant":[
+        "\u0e23\u0e31\u0e10\u0e2d\u0e31\u0e08\u0e0d\u0e4c\u0e21\u0e32\u0e19"
+    ],
     "name:tur_x_preferred":[
         "Acman"
     ],
@@ -287,6 +308,9 @@
     "name:vie_x_preferred":[
         "Ajman"
     ],
+    "name:wuu_x_preferred":[
+        "\u963f\u6cbb\u66fc\u914b\u957f\u56fd"
+    ],
     "name:xmf_x_preferred":[
         "\u10d0\u10ef\u10db\u10d0\u10dc\u10d8\u10e8 \u10e1\u10d0\u10d0\u10db\u10d8\u10e0\u10dd"
     ],
@@ -298,6 +322,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u5409\u66fc"
+    ],
+    "name:zho_x_variant":[
+        "\u963f\u6cbb\u66fc\u914b\u957f\u56fd"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ARE",
@@ -430,7 +457,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1663974531,
+    "wof:lastmodified":1690848515,
     "wof:name":"Ajman",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/77/85667977.geojson
+++ b/data/856/679/77/85667977.geojson
@@ -61,6 +61,9 @@
     "name:ben_x_preferred":[
         "\u09b6\u09be\u09b0\u099c\u09be\u09b9 \u0986\u09ae\u09bf\u09b0\u09be\u09a4"
     ],
+    "name:bos_x_preferred":[
+        "Sharjah"
+    ],
     "name:bre_x_preferred":[
         "Charjah"
     ],
@@ -78,6 +81,9 @@
     ],
     "name:dan_x_preferred":[
         "Sharjah"
+    ],
+    "name:dan_x_variant":[
+        "Emiratet Sharjah"
     ],
     "name:deu_x_preferred":[
         "Schardscha"
@@ -189,6 +195,9 @@
     "name:msa_x_preferred":[
         "Sharjah"
     ],
+    "name:msa_x_variant":[
+        "Emiriah Sharjah"
+    ],
     "name:nan_x_preferred":[
         "Sharjah Th\u00e2u-l\u00e2ng-kok"
     ],
@@ -282,8 +291,14 @@
     "name:urd_x_preferred":[
         "\u0634\u0627\u0631\u062c\u06c1"
     ],
+    "name:uzb_x_preferred":[
+        "Sharja amirligi"
+    ],
     "name:vie_x_preferred":[
         "Sharjah"
+    ],
+    "name:wuu_x_preferred":[
+        "\u6c99\u8fe6\u914b\u957f\u56fd"
     ],
     "name:xmf_x_preferred":[
         "\u10e8\u10d0\u10e0\u10ef\u10d0\u10e8 \u10e1\u10d0\u10d0\u10db\u10d8\u10e0\u10dd"
@@ -296,6 +311,9 @@
     ],
     "name:zho_x_preferred":[
         "\u590f\u5c14\u8fe6"
+    ],
+    "name:zho_x_variant":[
+        "\u6c99\u8fe6\u914b\u9577\u570b"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ARE",
@@ -425,7 +443,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1663974532,
+    "wof:lastmodified":1690848517,
     "wof:name":"Sharjah",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/81/85667981.geojson
+++ b/data/856/679/81/85667981.geojson
@@ -48,7 +48,11 @@
     ],
     "name:ara_x_variant":[
         "\u0625\u0645\u0627\u0631\u0629 \u0623\u0628\u0648\u0638\u0628\u064a",
-        "\u0623\u0628\u0648\u0638\u0628\u064a"
+        "\u0623\u0628\u0648\u0638\u0628\u064a",
+        "\u0625\u0645\u0627\u0631\u0629 \u0623\u0628\u0648 \u0638\u0628\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0645\u0627\u0631\u0629 \u0627\u0628\u0648\u0638\u0628\u0649"
     ],
     "name:ast_x_preferred":[
         "Emiratu d'Abu Dhabi"
@@ -70,6 +74,9 @@
     ],
     "name:ben_x_preferred":[
         "\u0986\u09ac\u09c1\u09a7\u09be\u09ac\u09bf \u0986\u09ae\u09bf\u09b0\u09be\u09a4"
+    ],
+    "name:bos_x_preferred":[
+        "Abu Dhabi"
     ],
     "name:bre_x_preferred":[
         "Abu Dhabi"
@@ -95,18 +102,23 @@
     "name:ell_x_preferred":[
         "\u0386\u03bc\u03c0\u03bf\u03c5 \u039d\u03c4\u03ac\u03bc\u03c0\u03b9"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03bc\u03b9\u03c1\u03ac\u03c4\u03bf \u03c4\u03bf\u03c5 \u0386\u03bc\u03c0\u03bf\u03c5 \u039d\u03c4\u03ac\u03bc\u03c0\u03b9"
+    ],
     "name:eng_x_preferred":[
         "Abu Dhabi"
     ],
     "name:eng_x_variant":[
         "Abu Zaby",
-        "Abu Dhabi Emirate"
+        "Abu Dhabi Emirate",
+        "Emirate of Abu Dhabi"
     ],
     "name:epo_x_preferred":[
         "Abu-Dabio"
     ],
     "name:epo_x_variant":[
-        "Abudabio"
+        "Abudabio",
+        "Emirlando Abudabio"
     ],
     "name:est_x_preferred":[
         "Abu Dhabi emiraat"
@@ -123,6 +135,9 @@
     "name:fin_x_preferred":[
         "Abu Dhabi Emirate"
     ],
+    "name:fin_x_variant":[
+        "Abu Dhabin emiirikunta"
+    ],
     "name:fra_x_preferred":[
         "Abou Dabi"
     ],
@@ -137,6 +152,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0a85\u0aac\u0ac1 \u0aa7\u0abe\u0aac\u0ac0 \u0a85\u0aae\u0ac0\u0ab0\u0abe\u0aa4"
+    ],
+    "name:hau_x_preferred":[
+        "Abu Dhabi"
     ],
     "name:heb_x_preferred":[
         "\u05d0\u05d1\u05d5 \u05d3\u05d0\u05d1\u05d9"
@@ -190,7 +208,8 @@
         "\uc544\ubd80\ub2e4\ube44"
     ],
     "name:kor_x_variant":[
-        "\uc544\ubd80\ub2e4\ube44 \ud1a0\ud6c4\uad6d"
+        "\uc544\ubd80\ub2e4\ube44 \ud1a0\ud6c4\uad6d",
+        "\uc544\ubd80\ub2e4\ube44\uc758 \ud1a0\ud6c4\uad6d"
     ],
     "name:kur_x_preferred":[
         "\u00cemarata Ab\u00fb Zeb\u00ee"
@@ -234,6 +253,9 @@
     "name:nan_x_preferred":[
         "Abu Dhabi Th\u00e2u-l\u00e2ng-kok"
     ],
+    "name:nep_x_preferred":[
+        "\u0905\u092c\u0941 \u0927\u093e\u092c\u0940 \u0907\u092e\u093f\u0930\u0947\u091f\u094d\u0938"
+    ],
     "name:nld_x_preferred":[
         "Abu Dhabi"
     ],
@@ -246,6 +268,9 @@
     "name:nor_x_preferred":[
         "Abu Dhabi"
     ],
+    "name:oci_x_preferred":[
+        "Emirat d'Abu Dhabi"
+    ],
     "name:pan_x_preferred":[
         "\u0a05\u0a2c\u0a42 \u0a27\u0a3e\u0a2c\u0a40"
     ],
@@ -257,6 +282,9 @@
     ],
     "name:por_x_preferred":[
         "Emirados Abu Dhabi"
+    ],
+    "name:pus_x_preferred":[
+        "\u0627\u0628\u0648\u0638\u0628\u06cd"
     ],
     "name:ron_x_preferred":[
         "Abu Dhabi"
@@ -324,8 +352,17 @@
     "name:urd_x_variant":[
         "\u0627\u0628\u0648\u0638\u0628\u06cc"
     ],
+    "name:uzb_x_preferred":[
+        "Abu-Dabi"
+    ],
     "name:vie_x_preferred":[
         "Abu Dhabi"
+    ],
+    "name:war_x_preferred":[
+        "Emirato han Abu Dhabi"
+    ],
+    "name:wuu_x_preferred":[
+        "\u963f\u5e03\u624e\u6bd4\u914b\u957f\u56fd"
     ],
     "name:xmf_x_preferred":[
         "\u10d0\u10d1\u10e3-\u10d3\u10d0\u10d1\u10d8\u10e8 \u10e1\u10d0\u10d0\u10db\u10d8\u10e0\u10dd"
@@ -468,7 +505,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1663974532,
+    "wof:lastmodified":1690848516,
     "wof:name":"Abu Dhabi",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/83/85667983.geojson
+++ b/data/856/679/83/85667983.geojson
@@ -64,6 +64,9 @@
     "name:arz_x_preferred":[
         "\u062f\u0628\u0649"
     ],
+    "name:arz_x_variant":[
+        "\u0627\u0645\u0627\u0631\u0629 \u062f\u0628\u0649"
+    ],
     "name:asm_x_preferred":[
         "\u09a1\u09c1\u09ac\u09be\u0987"
     ],
@@ -122,6 +125,9 @@
     "name:ckb_x_preferred":[
         "\u062f\u0648\u0628\u06d5\u06cc"
     ],
+    "name:ckb_x_variant":[
+        "\u0645\u06cc\u0631\u0646\u0634\u06cc\u0646\u06cc \u062f\u0648\u0628\u06d5\u06cc"
+    ],
     "name:cor_x_preferred":[
         "Dubai"
     ],
@@ -130,6 +136,9 @@
     ],
     "name:dan_x_preferred":[
         "Dubai"
+    ],
+    "name:dan_x_variant":[
+        "Emiratet Dubai"
     ],
     "name:deu_x_preferred":[
         "Dubai"
@@ -210,6 +219,9 @@
     "name:hak_x_preferred":[
         "Dubai"
     ],
+    "name:hau_x_preferred":[
+        "Dubai"
+    ],
     "name:hbs_x_preferred":[
         "Dubai"
     ],
@@ -285,6 +297,9 @@
     "name:kaz_x_preferred":[
         "\u0414\u0443\u0431\u0430\u0439"
     ],
+    "name:khm_x_preferred":[
+        "\u1791\u17b8\u1780\u17d2\u179a\u17bb\u1784\u178c\u17bc\u1794\u17c3"
+    ],
     "name:kik_x_preferred":[
         "Dubai"
     ],
@@ -327,6 +342,9 @@
     "name:mkd_x_preferred":[
         "\u0414\u0443\u0431\u0430\u0438"
     ],
+    "name:mni_x_preferred":[
+        "\uabd7\uabe8\uabd5\uabe5\uabe2 \uabc2\uabe9\uabc4\uabe5\uabdb"
+    ],
     "name:mon_x_preferred":[
         "\u0414\u0443\u0431\u0430\u0439 \u0445\u043e\u0442"
     ],
@@ -336,6 +354,9 @@
     ],
     "name:msa_x_preferred":[
         "Dubai"
+    ],
+    "name:msa_x_variant":[
+        "Amiriah Dubai"
     ],
     "name:mya_x_preferred":[
         "\u1012\u1030\u1018\u102d\u102f\u1004\u103a\u1038\u1019\u103c\u102d\u102f\u1037"
@@ -675,7 +696,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1663974532,
+    "wof:lastmodified":1690848517,
     "wof:name":"Dubai",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/859/030/19/85903019.geojson
+++ b/data/859/030/19/85903019.geojson
@@ -34,6 +34,9 @@
     "name:eng_x_preferred":[
         "Al Satwa"
     ],
+    "name:epo_x_preferred":[
+        "Alsat\u016da"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0633\u0637\u0648\u0629"
     ],
@@ -54,6 +57,9 @@
     ],
     "name:swe_x_preferred":[
         "Satwa"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0633\u0637\u0648\u06c1"
     ],
     "name:vie_x_preferred":[
         "Al Satwa"
@@ -102,7 +108,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1663974529,
+    "wof:lastmodified":1690848513,
     "wof:name":"Al Satwa",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/35/85907035.geojson
+++ b/data/859/070/35/85907035.geojson
@@ -37,6 +37,9 @@
     "name:eng_x_variant":[
         "Al Twar 1"
     ],
+    "name:epo_x_preferred":[
+        "Alt\u016dar"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0637\u0648\u0627\u0631"
     ],
@@ -45,6 +48,12 @@
     ],
     "name:ita_x_preferred":[
         "Al Twar"
+    ],
+    "name:nld_x_preferred":[
+        "Al Twar"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0637\u0648\u0627\u0631"
     ],
     "qs:gn_id":0,
     "reversegeo:latitude":25.272772,
@@ -90,7 +99,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1663974528,
+    "wof:lastmodified":1690848511,
     "wof:name":"Al Twar",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/37/85907037.geojson
+++ b/data/859/070/37/85907037.geojson
@@ -32,6 +32,9 @@
     "name:eng_x_preferred":[
         "Al Rashidiya"
     ],
+    "name:epo_x_preferred":[
+        "Alra\u015didija"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0631\u0627\u0634\u062f\u06cc\u0629"
     ],
@@ -44,8 +47,14 @@
     "name:ita_x_preferred":[
         "Al Rashidiya"
     ],
+    "name:nld_x_preferred":[
+        "Al Rashidiya"
+    ],
     "name:und_x_variant":[
         "Rash\u012bd\u012byah"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0631\u0627\u0634\u062f\u06cc\u06c1"
     ],
     "qs:gn_adm0_cc":"AE",
     "qs:gn_fcode":"PPLX",
@@ -117,7 +126,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1663974528,
+    "wof:lastmodified":1690848512,
     "wof:name":"Al Rashidiya",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/41/85907041.geojson
+++ b/data/859/070/41/85907041.geojson
@@ -32,11 +32,23 @@
     "name:eng_x_preferred":[
         "Za'abeel"
     ],
+    "name:epo_x_preferred":[
+        "Zabil"
+    ],
     "name:fas_x_preferred":[
         "\u0632\u0639\u0628\u06cc\u0644"
     ],
     "name:ind_x_preferred":[
         "Zabeel"
+    ],
+    "name:ita_x_preferred":[
+        "Zabeel"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b6\u30d3\u30fc\u30eb"
+    ],
+    "name:nld_x_preferred":[
+        "Za'abeel"
     ],
     "name:und_x_variant":[
         "Raml Sabil"
@@ -97,7 +109,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1663974528,
+    "wof:lastmodified":1690848512,
     "wof:name":"Za'abeel",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/45/85907045.geojson
+++ b/data/859/070/45/85907045.geojson
@@ -32,6 +32,9 @@
     "name:eng_x_preferred":[
         "Al Wasl"
     ],
+    "name:epo_x_preferred":[
+        "Al\u016dasl"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0648\u0635\u0644"
     ],
@@ -44,8 +47,17 @@
     "name:jpn_x_preferred":[
         "\u30a2\u30eb\u30fb\u30ef\u30b9\u30eb"
     ],
+    "name:nld_x_preferred":[
+        "Al Wasl"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0648\u0635\u0644"
+    ],
     "name:vie_x_preferred":[
         "Al Wasl"
+    ],
+    "name:zho_x_preferred":[
+        "\u963f\u723e\u74e6\u65af\u723e"
     ],
     "reversegeo:latitude":25.198252,
     "reversegeo:longitude":55.256618,
@@ -92,7 +104,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1663974528,
+    "wof:lastmodified":1690848511,
     "wof:name":"Al Wasl",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/47/85907047.geojson
+++ b/data/859/070/47/85907047.geojson
@@ -34,6 +34,9 @@
     "name:eng_x_variant":[
         "Al Bada"
     ],
+    "name:epo_x_preferred":[
+        "Albada"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0628\u062f\u0639"
     ],
@@ -42,6 +45,12 @@
     ],
     "name:ita_x_preferred":[
         "Al Bada"
+    ],
+    "name:nld_x_preferred":[
+        "Al Bada"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0628\u062f\u0639"
     ],
     "qs:gn_id":0,
     "reversegeo:latitude":25.232523,
@@ -87,7 +96,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1663974528,
+    "wof:lastmodified":1690848513,
     "wof:name":"Al Bada'a",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/49/85907049.geojson
+++ b/data/859/070/49/85907049.geojson
@@ -44,14 +44,26 @@
     "name:fas_x_variant":[
         "\u0627\u0644\u06a9\u0631\u0627\u0645\u0647"
     ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05dc \u05e7\u05e8\u05d0\u05de\u05d4"
+    ],
     "name:ind_x_preferred":[
         "Al Karama"
     ],
     "name:ita_x_preferred":[
         "Al Karama"
     ],
+    "name:mal_x_preferred":[
+        "\u0d05\u0d7d \u0d15\u0d31\u0d3e\u0d2e"
+    ],
     "name:nld_x_preferred":[
         "Al Karama"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u043b\u044c \u041a\u0430\u0440\u0430\u043c\u0430"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u06a9\u0631\u0627\u0645\u06c1"
     ],
     "reversegeo:latitude":25.244961,
     "reversegeo:longitude":55.304744,
@@ -98,7 +110,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1663974528,
+    "wof:lastmodified":1690848513,
     "wof:name":"Al Karama",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/51/85907051.geojson
+++ b/data/859/070/51/85907051.geojson
@@ -41,14 +41,23 @@
         "Pt Saeed",
         "Pt. Saeed"
     ],
+    "name:epo_x_preferred":[
+        "Said Haveno"
+    ],
     "name:ind_x_preferred":[
         "Pelabuhan Saeed"
     ],
     "name:ita_x_preferred":[
         "Port Saeed"
     ],
+    "name:nld_x_preferred":[
+        "Port Saeed"
+    ],
     "name:und_x_variant":[
         "B\u016br Sa\u2018\u012bd"
+    ],
+    "name:urd_x_preferred":[
+        "\u0628\u0646\u062f\u0631\u06af\u0627\u06c1 \u0633\u0639\u06cc\u062f"
     ],
     "qs:gn_adm0_cc":"AE",
     "qs:gn_fcode":"PPLX",
@@ -122,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1663974528,
+    "wof:lastmodified":1690848511,
     "wof:name":"Port Saeed",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/57/85907057.geojson
+++ b/data/859/070/57/85907057.geojson
@@ -34,11 +34,20 @@
     "name:eng_x_preferred":[
         "Al Ras"
     ],
+    "name:epo_x_preferred":[
+        "Alras"
+    ],
     "name:ind_x_preferred":[
         "Al Ras"
     ],
     "name:ita_x_preferred":[
         "Al Ras"
+    ],
+    "name:nld_x_preferred":[
+        "Al Ras"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0631\u0627\u0633"
     ],
     "qs:gn_id":0,
     "reversegeo:latitude":25.267978,
@@ -84,7 +93,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1663974528,
+    "wof:lastmodified":1690848511,
     "wof:name":"Al Ras",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/59/85907059.geojson
+++ b/data/859/070/59/85907059.geojson
@@ -47,6 +47,9 @@
     "name:ita_x_preferred":[
         "Al Rigga"
     ],
+    "name:nld_x_preferred":[
+        "Al Rigga"
+    ],
     "name:und_x_variant":[
         "Ar Riqqah"
     ],
@@ -120,7 +123,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1663974528,
+    "wof:lastmodified":1690848510,
     "wof:name":"Al Rigga",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/65/85907065.geojson
+++ b/data/859/070/65/85907065.geojson
@@ -37,6 +37,9 @@
     "name:eng_x_variant":[
         "Al Quoz"
     ],
+    "name:epo_x_preferred":[
+        "Alkoz"
+    ],
     "name:fas_x_preferred":[
         "\u062d\u06cc \u0627\u0644\u0642\u0648\u0632"
     ],
@@ -45,6 +48,12 @@
     ],
     "name:ita_x_preferred":[
         "Al Quoz"
+    ],
+    "name:nld_x_preferred":[
+        "Al Quoz"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0642\u0648\u0632"
     ],
     "name:vie_x_preferred":[
         "Al Quoz"
@@ -93,7 +102,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1663974528,
+    "wof:lastmodified":1690848512,
     "wof:name":"Al Quoz 1",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/67/85907067.geojson
+++ b/data/859/070/67/85907067.geojson
@@ -38,14 +38,29 @@
     "name:eng_x_variant":[
         "Nad Al Sheba"
     ],
+    "name:epo_x_preferred":[
+        "Nad A\u015d\u015deba"
+    ],
     "name:fas_x_preferred":[
         "\u0646\u062f \u0627\u0644\u0634\u0628\u0627"
     ],
     "name:ind_x_preferred":[
         "Nad Al Sheba"
     ],
+    "name:ita_x_preferred":[
+        "Nad Al Sheba"
+    ],
+    "name:nld_x_preferred":[
+        "Nad Al Sheba"
+    ],
     "name:und_x_variant":[
         "Nadd Shubay\u1e29"
+    ],
+    "name:urd_x_preferred":[
+        "\u0646\u062f \u0627\u0644\u0634\u0628\u0627"
+    ],
+    "name:zho_x_preferred":[
+        "\u7d0d\u5fb7\u8b1d\u5df4"
     ],
     "qs:gn_adm0_cc":"AE",
     "qs:gn_fcode":"PPL",
@@ -119,7 +134,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1663974528,
+    "wof:lastmodified":1690848511,
     "wof:name":"Nadd Al Shiba",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/69/85907069.geojson
+++ b/data/859/070/69/85907069.geojson
@@ -53,6 +53,9 @@
     "name:nld_x_preferred":[
         "Mirdif"
     ],
+    "name:urd_x_preferred":[
+        "\u0645\u0631\u062f\u0641"
+    ],
     "qs:gn_adm0_cc":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_local":292223,
@@ -123,7 +126,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1663974528,
+    "wof:lastmodified":1690848511,
     "wof:name":"Mirdif",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/71/85907071.geojson
+++ b/data/859/070/71/85907071.geojson
@@ -29,12 +29,18 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0631\u0641\u0627\u0639\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0631\u0641\u0627\u0639\u0647"
+    ],
     "name:eng_x_preferred":[
         "Al Raffa"
     ],
     "name:eng_x_variant":[
         "Al Rifa'a",
         "Al Rifa"
+    ],
+    "name:epo_x_preferred":[
+        "Alrafa"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0631\u0641\u0627\u0639\u0629"
@@ -50,6 +56,9 @@
     ],
     "name:und_x_variant":[
         "Ar Rif\u0101\u2018ah"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0631\u0641\u0627\u0639\u06c1"
     ],
     "qs:gn_adm0_cc":"AE",
     "qs:gn_fcode":"PPLX",
@@ -120,7 +129,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1663974528,
+    "wof:lastmodified":1690848512,
     "wof:name":"Al Raffa",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/070/73/85907073.geojson
+++ b/data/859/070/73/85907073.geojson
@@ -53,8 +53,14 @@
     "name:ita_x_preferred":[
         "Al Sabkha"
     ],
+    "name:nld_x_preferred":[
+        "Al Sabkha"
+    ],
     "name:und_x_variant":[
         "As Sabkhah"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0633\u0628\u062e\u06c1"
     ],
     "qs:gn_adm0_cc":"AE",
     "qs:gn_fcode":"PPLX",
@@ -126,7 +132,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1663974528,
+    "wof:lastmodified":1690848512,
     "wof:name":"Al Sabkha",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/302/93/85930293.geojson
+++ b/data/859/302/93/85930293.geojson
@@ -39,14 +39,26 @@
         "Community 362",
         "Umm Suqeim"
     ],
+    "name:epo_x_preferred":[
+        "Um Sukejm"
+    ],
     "name:fas_x_preferred":[
         "\u0623\u0645 \u0633\u0642\u06cc\u0645"
     ],
     "name:ind_x_preferred":[
         "Umm Suqeim"
     ],
+    "name:ita_x_preferred":[
+        "Umm Suqeim"
+    ],
+    "name:nld_x_preferred":[
+        "Umm Suqeim"
+    ],
     "name:swe_x_preferred":[
         "Umm Suqeim"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0645 \u0633\u0642\u06cc\u0645"
     ],
     "qs:gn_adm0_cc":"AE",
     "qs:gn_id":0,
@@ -81,11 +93,11 @@
     "wd:longitude":55.214539,
     "wd:wordcount":220,
     "wof:belongsto":[
+        85667983,
         102191569,
         85632573,
         421174961,
-        1376833603,
-        85667983
+        1376833603
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -113,7 +125,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1663973919,
+    "wof:lastmodified":1690848514,
     "wof:name":"Umm Suqeim 2",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/304/05/85930405.geojson
+++ b/data/859/304/05/85930405.geojson
@@ -35,14 +35,26 @@
         "Umm Suqeim 1",
         "Community 356"
     ],
+    "name:epo_x_preferred":[
+        "Um Sukejm"
+    ],
     "name:fas_x_preferred":[
         "\u0623\u0645 \u0633\u0642\u06cc\u0645"
     ],
     "name:ind_x_preferred":[
         "Umm Suqeim"
     ],
+    "name:ita_x_preferred":[
+        "Umm Suqeim"
+    ],
+    "name:nld_x_preferred":[
+        "Umm Suqeim"
+    ],
     "name:swe_x_preferred":[
         "Umm Suqeim"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0645 \u0633\u0642\u06cc\u0645"
     ],
     "qs:gn_adm0_cc":"AE",
     "qs:gn_id":0,
@@ -113,7 +125,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1663974529,
+    "wof:lastmodified":1690848513,
     "wof:name":"Umm Suqeim",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/859/305/91/85930591.geojson
+++ b/data/859/305/91/85930591.geojson
@@ -32,6 +32,9 @@
     "name:eng_x_preferred":[
         "Al Mushrif"
     ],
+    "name:nld_x_preferred":[
+        "Al Mushrif"
+    ],
     "qs:gn_adm0_cc":"AE",
     "qs:gn_fcode":"PPLX",
     "qs:gn_local":292968,
@@ -102,7 +105,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1663974530,
+    "wof:lastmodified":1690848514,
     "wof:name":"Al Mushrif",
     "wof:parent_id":421179641,
     "wof:placetype":"neighbourhood",

--- a/data/859/306/03/85930603.geojson
+++ b/data/859/306/03/85930603.geojson
@@ -28,11 +28,17 @@
     "name:ara_x_preferred":[
         "\u0623\u0645 \u0631\u0645\u0648\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0645 \u0631\u0645\u0648\u0644"
+    ],
     "name:eng_x_preferred":[
         "Umm Ramool"
     ],
     "name:eng_x_variant":[
         "Community 215"
+    ],
+    "name:epo_x_preferred":[
+        "Um Ramul"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0645 \u0631\u0645\u0648\u0644"
@@ -45,6 +51,9 @@
     ],
     "name:nld_x_preferred":[
         "Umm Ramool"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0645 \u0631\u0645\u0648\u0644"
     ],
     "qs:gn_adm0_cc":"AE",
     "qs:gn_id":0,
@@ -113,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1663974527,
+    "wof:lastmodified":1690848510,
     "wof:name":"Umm Ramool",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",

--- a/data/890/455/645/890455645.geojson
+++ b/data/890/455/645/890455645.geojson
@@ -31,6 +31,9 @@
     "name:ast_x_preferred":[
         "Emiratu d'Umm al-Qaywayn"
     ],
+    "name:aze_x_preferred":[
+        "\u00dcmm \u0259l-Qeyveyn \u0259mirliyi"
+    ],
     "name:bel_x_preferred":[
         "\u042d\u043c\u0456\u0440\u0430\u0442 \u0423\u043c-\u044d\u043b\u044c-\u041a\u0430\u0439\u0432\u0430\u0439\u043d"
     ],
@@ -39,6 +42,12 @@
     ],
     "name:ben_x_preferred":[
         "\u0989\u09ae\u09cd\u09ae\u09c1\u09b2 \u0995\u09c1\u09af\u09bc\u09be\u0987\u09a8"
+    ],
+    "name:ben_x_variant":[
+        "\u0989\u09ae\u09cd\u09ae \u0986\u09b2 \u0995\u09cb\u09af\u09bc\u09be\u0987\u09a8 \u0986\u09ae\u09bf\u09b0\u09be\u09a4"
+    ],
+    "name:bos_x_preferred":[
+        "Umm al-Quwain"
     ],
     "name:bre_x_preferred":[
         "Umm al-Qaywayn"
@@ -58,6 +67,9 @@
     "name:dan_x_preferred":[
         "Umm Al Quwain"
     ],
+    "name:dan_x_variant":[
+        "Emiratet Umm Al Quwain"
+    ],
     "name:deu_x_preferred":[
         "Umm al-Qaiwain"
     ],
@@ -67,8 +79,14 @@
     "name:eng_x_preferred":[
         "Umm al-Quwain"
     ],
+    "name:eng_x_variant":[
+        "Emirate of Umm Al Quwain"
+    ],
     "name:epo_x_preferred":[
         "Um-al-Kajvajno"
+    ],
+    "name:epo_x_variant":[
+        "Umalkajvajno"
     ],
     "name:est_x_preferred":[
         "Umm al-Qaywayni emiraat"
@@ -226,6 +244,9 @@
     "name:tha_x_preferred":[
         "\u0e23\u0e31\u0e10\u0e2d\u0e38\u0e21\u0e21\u0e4c\u0e2d\u0e31\u0e25\u0e44\u0e01\u0e44\u0e27\u0e19\u0e4c"
     ],
+    "name:tha_x_variant":[
+        "\u0e23\u0e31\u0e10\u0e2d\u0e38\u0e21\u0e21\u0e4c\u0e2d\u0e31\u0e25\u0e01\u0e38\u0e40\u0e27\u0e19"
+    ],
     "name:tur_x_preferred":[
         "Umm\u00fcl-Kayveyn Emirli\u011fi"
     ],
@@ -247,6 +268,12 @@
     "name:vie_x_variant":[
         "Umm al-Quwain"
     ],
+    "name:war_x_preferred":[
+        "Emirato han Umm Al Quwain"
+    ],
+    "name:wuu_x_preferred":[
+        "\u4e4c\u59c6\u76d6\u4e07\u914b\u957f\u56fd"
+    ],
     "name:xmf_x_preferred":[
         "\u10e3\u10db-\u10d4\u10da-\u10e5\u10d0\u10d8\u10d5\u10d0\u10d8\u10dc\u10d8\u10e8 \u10e1\u10d0\u10d0\u10db\u10d8\u10e0\u10dd"
     ],
@@ -255,6 +282,9 @@
     ],
     "name:yue_x_preferred":[
         "\u6b50\u59c6\u53e4\u6eab\u914b\u9577\u570b"
+    ],
+    "name:yue_x_variant":[
+        "\u70cf\u59c6\u84cb\u842c\u914b\u9577\u570b"
     ],
     "name:zho_cn_x_preferred":[
         "\u4e4c\u59c6\u76d6\u4e07"
@@ -266,7 +296,8 @@
         "\u6b27\u59c6\u53e4\u6e29"
     ],
     "name:zho_x_variant":[
-        "\u70cf\u59c6\u84cb\u842c"
+        "\u70cf\u59c6\u84cb\u842c",
+        "\u4e4c\u59c6\u76d6\u4e07\u914b\u957f\u56fd"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"United Arab Emirates",
@@ -405,7 +436,7 @@
         }
     ],
     "wof:id":890455645,
-    "wof:lastmodified":1663974539,
+    "wof:lastmodified":1690848524,
     "wof:name":"Umm al Qaywayn",
     "wof:parent_id":1376833609,
     "wof:placetype":"locality",

--- a/data/890/455/647/890455647.geojson
+++ b/data/890/455/647/890455647.geojson
@@ -28,6 +28,9 @@
     "name:ara_x_preferred":[
         "\u0631\u0623\u0633 \u0627\u0644\u062e\u064a\u0645\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0631\u0627\u0633 \u0627\u0644\u062e\u064a\u0645\u0629"
+    ],
     "name:bel_x_preferred":[
         "\u042d\u043c\u0456\u0440\u0430\u0442 \u0420\u0430\u0441-\u044d\u043b\u044c-\u0425\u0430\u0439\u043c\u0430"
     ],
@@ -36,6 +39,12 @@
     ],
     "name:ben_x_preferred":[
         "\u09b0\u09be\u09b8 \u0986\u09b2-\u0996\u09be\u0987\u09ae\u09be\u09b9"
+    ],
+    "name:ben_x_variant":[
+        "\u09b0\u09be\u09b8 \u0986\u09b2 \u0996\u09be\u0987\u09ae\u09be\u09b9 \u0986\u09ae\u09bf\u09b0\u09be\u09a4"
+    ],
+    "name:bos_x_preferred":[
+        "Ras al-Khaimah"
     ],
     "name:bre_x_preferred":[
         "Ras al-Khaimah"
@@ -58,20 +67,30 @@
     "name:dan_x_preferred":[
         "Ras al-Khaimah"
     ],
+    "name:dan_x_variant":[
+        "Emiratet Ras al-Khaimah"
+    ],
     "name:deu_x_preferred":[
         "Ra\u2019s al-Chaima"
     ],
     "name:ell_x_preferred":[
         "\u03a1\u03b1\u03c2 \u03b1\u03bb-\u039a\u03b1\u03ca\u03bc\u03ac"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03bc\u03b9\u03c1\u03ac\u03c4\u03bf \u03c4\u03bf\u03c5 \u03a1\u03b1\u03c2 \u03b1\u03bb-\u03a7\u03b1\u03ca\u03bc\u03ac"
+    ],
     "name:eng_x_preferred":[
         "Ras al-Khaimah"
     ],
     "name:eng_x_variant":[
-        "Ras el-Kheima"
+        "Ras el-Kheima",
+        "Emirate of Ras Al Khaimah"
     ],
     "name:epo_x_preferred":[
         "Ras-al-\u0124ajmo"
+    ],
+    "name:epo_x_variant":[
+        "Rasal\u0125ajmo"
     ],
     "name:est_x_preferred":[
         "Ra's al-Khaymah' emiraat"
@@ -87,6 +106,9 @@
     ],
     "name:fra_x_preferred":[
         "Ras el Kha\u00efmah"
+    ],
+    "name:glg_x_preferred":[
+        "Ras al-Jaimah"
     ],
     "name:guj_x_preferred":[
         "\u0ab0\u0abe\u0ab8 \u0a85\u0ab2-\u0a96\u0ac8\u0aae\u0abe\u0ab9"
@@ -112,8 +134,14 @@
     "name:hye_x_variant":[
         "\u054c\u0561\u057d \u0561\u056c-\u053d\u0561\u0575\u0574\u0561\u0575\u056b \u0537\u0574\u056b\u0580\u0578\u0582\u0569\u0575\u0578\u0582\u0576"
     ],
+    "name:hyw_x_preferred":[
+        "\u054c\u0561\u057d \u0561\u056c \u053d\u0561\u0575\u0574\u0561"
+    ],
     "name:ind_x_preferred":[
         "Ras al-Khaimah"
+    ],
+    "name:isl_x_preferred":[
+        "Ras al-Ka\u00edma"
     ],
     "name:ita_x_preferred":[
         "Ras al-Khaima"
@@ -150,6 +178,9 @@
     ],
     "name:msa_x_preferred":[
         "Ras al-Khaimah"
+    ],
+    "name:msa_x_variant":[
+        "Emiriah Ras al-Khaimah"
     ],
     "name:nan_x_preferred":[
         "Ras al-Khaimah"
@@ -236,11 +267,17 @@
     "name:tel_x_preferred":[
         "\u0c30\u0c3e\u0c38\u0c4d \u0c05\u0c32\u0c4d-\u0c16\u0c48\u0c2e\u0c3e"
     ],
+    "name:tgk_x_preferred":[
+        "\u0420\u0430\u044a\u0441\u0443-\u043b-\u0425\u0430\u0439\u043c\u0430"
+    ],
     "name:tgl_x_preferred":[
         "Ras al-Khaimah"
     ],
     "name:tha_x_preferred":[
         "\u0e23\u0e31\u0e10\u0e23\u0e32\u0e2a\u0e2d\u0e31\u0e25\u0e44\u0e04\u0e21\u0e32\u0e2b\u0e4c"
+    ],
+    "name:tha_x_variant":[
+        "\u0e23\u0e31\u0e10\u0e40\u0e23\u0e32\u0e30\u0e0b\u0e38\u0e25\u0e04\u0e31\u0e22\u0e21\u0e30\u0e2e\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Res\u00fc'l-Hayme"
@@ -260,6 +297,9 @@
     "name:war_x_preferred":[
         "Ras al-Kaimah"
     ],
+    "name:wuu_x_preferred":[
+        "\u54c8\u4f0a\u9a6c\u89d2\u914b\u957f\u56fd"
+    ],
     "name:xmf_x_preferred":[
         "\u10e0\u10d0\u10e1-\u10d4\u10da-\u10ee\u10d0\u10d8\u10db\u10d0\u10e8 \u10e1\u10d0\u10d0\u10db\u10d8\u10e0\u10dd"
     ],
@@ -271,6 +311,9 @@
     ],
     "name:zho_x_preferred":[
         "\u62c9\u65af\u6d77\u739b"
+    ],
+    "name:zho_x_variant":[
+        "\u62c9\u65af\u6d77\u746a\u914b\u9577\u570b"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"United Arab Emirates",
@@ -428,7 +471,7 @@
         }
     ],
     "wof:id":890455647,
-    "wof:lastmodified":1663974540,
+    "wof:lastmodified":1690848525,
     "wof:name":"Ra\u2019s al Khaymah",
     "wof:parent_id":1376833605,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.