### PR TITLE
ae concordances, placetype local, and more

### DIFF
--- a/data/137/682/638/7/1376826387.geojson
+++ b/data/137/682/638/7/1376826387.geojson
@@ -89,7 +89,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886556,
     "wof:name":"Dibba Al-Hisn",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/638/9/1376826389.geojson
+++ b/data/137/682/638/9/1376826389.geojson
@@ -68,7 +68,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886556,
     "wof:name":"Al Madam",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/639/1/1376826391.geojson
+++ b/data/137/682/639/1/1376826391.geojson
@@ -65,7 +65,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886556,
     "wof:name":"Al Bataeh",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/639/3/1376826393.geojson
+++ b/data/137/682/639/3/1376826393.geojson
@@ -65,7 +65,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886556,
     "wof:name":"Mleeha",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/639/7/1376826397.geojson
+++ b/data/137/682/639/7/1376826397.geojson
@@ -110,7 +110,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886556,
     "wof:name":"Kalba",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/640/1/1376826401.geojson
+++ b/data/137/682/640/1/1376826401.geojson
@@ -70,7 +70,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886555,
     "wof:name":"Al Hamriya",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/137/682/640/3/1376826403.geojson
+++ b/data/137/682/640/3/1376826403.geojson
@@ -86,7 +86,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886555,
     "wof:name":"Al Dhafra",
     "wof:parent_id":85667981,
     "wof:placetype":"county",

--- a/data/137/683/360/3/1376833603.geojson
+++ b/data/137/683/360/3/1376833603.geojson
@@ -658,12 +658,17 @@
         "gn:id":292224,
         "gp:id":2347111,
         "hasc:id":"AE.DU",
+        "iso:code":"AE-DU",
         "iso:id":"AE-DU",
         "qs_pg:id":1278641,
         "unlc:id":"AE-DU",
         "wd:id":"Q613",
         "wk:page":"Emirate of Dubai"
     },
+    "wof:concordances_official":"iso:code",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:coterminous":[
         85667983
     ],
@@ -687,7 +692,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886556,
     "wof:name":"Dubai",
     "wof:parent_id":85667983,
     "wof:placetype":"county",

--- a/data/137/683/360/5/1376833605.geojson
+++ b/data/137/683/360/5/1376833605.geojson
@@ -439,10 +439,15 @@
         "gn:id":291075,
         "gp:id":2347113,
         "hasc:id":"AE.RK",
+        "iso:code":"AE-RK",
         "iso:id":"AE-RK",
         "qs_pg:id":1135358,
         "wd:id":"Q170024"
     },
+    "wof:concordances_official":"iso:code",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:coterminous":[
         85667951
     ],
@@ -466,7 +471,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886557,
     "wof:name":"Ras Al Khaimah",
     "wof:parent_id":85667951,
     "wof:placetype":"county",

--- a/data/137/683/360/7/1376833607.geojson
+++ b/data/137/683/360/7/1376833607.geojson
@@ -420,11 +420,16 @@
         "gn:id":292933,
         "gp:id":2347110,
         "hasc:id":"AE.AJ",
+        "iso:code":"AE-AJ",
         "iso:id":"AE-AJ",
         "qs_pg:id":1311801,
         "wd:id":"Q159477",
         "wk:page":"Emirate of Ajman"
     },
+    "wof:concordances_official":"iso:code",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:coterminous":[
         85667969
     ],
@@ -448,7 +453,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886557,
     "wof:name":"Ajman",
     "wof:parent_id":85667969,
     "wof:placetype":"county",

--- a/data/137/683/360/9/1376833609.geojson
+++ b/data/137/683/360/9/1376833609.geojson
@@ -417,6 +417,7 @@
         "gn:id":290595,
         "gp:id":2347115,
         "hasc:id":"AE.UQ",
+        "iso:code":"AE-UQ",
         "iso:id":"AE-UQ",
         "nyt:id":"84442786730790533851",
         "qs_pg:id":890102,
@@ -424,6 +425,10 @@
         "wd:id":"Q175021",
         "wk:page":"Umm al-Quwain"
     },
+    "wof:concordances_official":"iso:code",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:coterminous":[
         85667955
     ],
@@ -447,7 +452,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886557,
     "wof:name":"Umm Al Quwain",
     "wof:parent_id":85667955,
     "wof:placetype":"county",

--- a/data/137/683/361/1/1376833611.geojson
+++ b/data/137/683/361/1/1376833611.geojson
@@ -410,12 +410,17 @@
         "gn:id":292879,
         "gp:id":2347112,
         "hasc:id":"AE.FU",
+        "iso:code":"AE-FU",
         "iso:id":"AE-FU",
         "qs_pg:id":218188,
         "unlc:id":"AE-FU",
         "wd:id":"Q4091",
         "wk:page":"Fujairah"
     },
+    "wof:concordances_official":"iso:code",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:coterminous":[
         85667959
     ],
@@ -439,7 +444,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886558,
     "wof:name":"Fujairah",
     "wof:parent_id":85667959,
     "wof:placetype":"county",

--- a/data/421/171/391/421171391.geojson
+++ b/data/421/171/391/421171391.geojson
@@ -308,7 +308,7 @@
         }
     ],
     "wof:id":421171391,
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886558,
     "wof:name":"Sharjah",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/421/172/075/421172075.geojson
+++ b/data/421/172/075/421172075.geojson
@@ -567,7 +567,7 @@
         }
     ],
     "wof:id":421172075,
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886558,
     "wof:name":"Abu Dhabi",
     "wof:parent_id":85667981,
     "wof:placetype":"county",

--- a/data/421/176/643/421176643.geojson
+++ b/data/421/176/643/421176643.geojson
@@ -117,7 +117,7 @@
         }
     ],
     "wof:id":421176643,
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886558,
     "wof:name":"Dhaid",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/421/182/269/421182269.geojson
+++ b/data/421/182/269/421182269.geojson
@@ -171,7 +171,7 @@
         }
     ],
     "wof:id":421182269,
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886558,
     "wof:name":"Khor Fakkan",
     "wof:parent_id":85667977,
     "wof:placetype":"county",

--- a/data/421/200/931/421200931.geojson
+++ b/data/421/200/931/421200931.geojson
@@ -304,7 +304,7 @@
         }
     ],
     "wof:id":421200931,
-    "wof:lastmodified":1694492303,
+    "wof:lastmodified":1695887184,
     "wof:name":"Al Ain",
     "wof:parent_id":85667981,
     "wof:placetype":"county",

--- a/data/856/325/73/85632573.geojson
+++ b/data/856/325/73/85632573.geojson
@@ -1340,6 +1340,7 @@
         "hasc:id":"AE",
         "icao:code":"A6",
         "ioc:id":"UAE",
+        "iso:code":"AE",
         "itu:id":"UAE",
         "loc:id":"n79086806",
         "m49:code":"784",
@@ -1353,6 +1354,7 @@
         "wk:page":"United Arab Emirates",
         "wmo:id":"ER"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AE",
     "wof:country_alpha3":"ARE",
     "wof:geom_alt":[
@@ -1373,7 +1375,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694639673,
+    "wof:lastmodified":1695881332,
     "wof:name":"United Arab Emirates",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/679/51/85667951.geojson
+++ b/data/856/679/51/85667951.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"1972-02-10",
     "geom:area":0.223142,
-    "geom:area_square_m":2493994525.105408,
+    "geom:area_square_m":2491299947.195134,
     "geom:bbox":"55.729594,24.820372,56.274683,26.069654",
     "geom:latitude":25.455256,
     "geom:longitude":56.033528,
@@ -451,10 +451,12 @@
         "gn:id":291075,
         "gp:id":2347113,
         "hasc:id":"AE.RK",
+        "iso:code":"AE-RK",
         "iso:id":"AE-RK",
         "qs_pg:id":1135358,
         "wd:id":"Q170024"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1376833605
     ],
@@ -462,7 +464,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6f051375c26ac061c53074ee2b554b53",
+    "wof:geomhash":"0859c7ed36ea7a0cadc706837b49bde1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -477,7 +479,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690848516,
+    "wof:lastmodified":1695885135,
     "wof:name":"Ras Al Khaimah",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/55/85667955.geojson
+++ b/data/856/679/55/85667955.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"1971-12-02",
     "geom:area":0.075987,
-    "geom:area_square_m":846488063.10508,
+    "geom:area_square_m":848167058.620829,
     "geom:bbox":"55.520564,25.277036,55.928142,25.662297",
     "geom:latitude":25.485378,
     "geom:longitude":55.73519,
@@ -427,6 +427,7 @@
         "gn:id":290595,
         "gp:id":2347115,
         "hasc:id":"AE.UQ",
+        "iso:code":"AE-UQ",
         "iso:id":"AE-UQ",
         "nyt:id":"84442786730790533851",
         "qs_pg:id":890102,
@@ -434,6 +435,7 @@
         "wd:id":"Q175021",
         "wk:page":"Umm al-Quwain"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1376833609
     ],
@@ -441,7 +443,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7bbaa97731b1a1d672fa92e41d2a1b28",
+    "wof:geomhash":"b61c3d5313932a845d5415a7bb65d439",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -456,7 +458,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690848516,
+    "wof:lastmodified":1695885135,
     "wof:name":"Umm Al Quwain",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/59/85667959.geojson
+++ b/data/856/679/59/85667959.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"1971-12-02",
     "geom:area":0.149435,
-    "geom:area_square_m":1666840514.60322,
+    "geom:area_square_m":1669805651.929381,
     "geom:bbox":"55.965711,24.871949,56.376705,25.662314",
     "geom:latitude":25.354051,
     "geom:longitude":56.19775,
@@ -420,12 +420,14 @@
         "gn:id":292879,
         "gp:id":2347112,
         "hasc:id":"AE.FU",
+        "iso:code":"AE-FU",
         "iso:id":"AE-FU",
         "qs_pg:id":218188,
         "unlc:id":"AE-FU",
         "wd:id":"Q4091",
         "wk:page":"Fujairah"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1376833611
     ],
@@ -433,7 +435,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e37db7984cc6e0f9c946bf7d6b57b761",
+    "wof:geomhash":"dd30bc8f9b874799b1305af99fe06d33",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -448,7 +450,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690848515,
+    "wof:lastmodified":1695885135,
     "wof:name":"Fujairah",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/63/85667963.geojson
+++ b/data/856/679/63/85667963.geojson
@@ -191,7 +191,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1695885135,
     "wof:name":"Neutral Zone",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/69/85667969.geojson
+++ b/data/856/679/69/85667969.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"1971-12-02",
     "geom:area":0.015847,
-    "geom:area_square_m":193540648.101557,
+    "geom:area_square_m":177033414.975196,
     "geom:bbox":"55.423316,25.282049,56.033211,25.45088",
     "geom:latitude":25.38614,
     "geom:longitude":55.615532,
@@ -430,11 +430,13 @@
         "gn:id":292933,
         "gp:id":2347110,
         "hasc:id":"AE.AJ",
+        "iso:code":"AE-AJ",
         "iso:id":"AE-AJ",
         "qs_pg:id":1311801,
         "wd:id":"Q159477",
         "wk:page":"Emirate of Ajman"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1376833607
     ],
@@ -442,7 +444,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b240f21a55c95a2d35ab456cc9e9d1cc",
+    "wof:geomhash":"b17fbdb00ef64dec95b804ba9b392103",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -457,7 +459,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690848515,
+    "wof:lastmodified":1695885135,
     "wof:name":"Ajman",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/73/85667973.geojson
+++ b/data/856/679/73/85667973.geojson
@@ -191,7 +191,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1695885135,
     "wof:name":"Neutral Zone",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/77/85667977.geojson
+++ b/data/856/679/77/85667977.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"1971-12-02",
     "geom:area":0.235556,
-    "geom:area_square_m":2621511590.517756,
+    "geom:area_square_m":2636993642.457028,
     "geom:bbox":"55.349781,24.690845,56.381701,25.629307",
     "geom:latitude":25.129963,
     "geom:longitude":55.799277,
@@ -419,16 +419,18 @@
         "gn:id":292673,
         "gp:id":2347114,
         "hasc:id":"AE.SH",
+        "iso:code":"AE-SH",
         "iso:id":"AE-SH",
         "qs_pg:id":1091222,
         "wd:id":"Q188810",
         "wk:page":"Emirate of Sharjah"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bc14dcb620c8a05ba080ccda99d20627",
+    "wof:geomhash":"f23e94ea43fad8d79da064ee39a97ce8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -443,7 +445,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690848517,
+    "wof:lastmodified":1695885135,
     "wof:name":"Sharjah",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/81/85667981.geojson
+++ b/data/856/679/81/85667981.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"1971-12-02",
     "geom:area":5.341013,
-    "geom:area_square_m":60581876606.696526,
+    "geom:area_square_m":60484586474.621964,
     "geom:bbox":"51.497112,22.631514,56.018126,25.251249",
     "geom:latitude":23.669486,
     "geom:longitude":54.042457,
@@ -480,17 +480,19 @@
         "gn:id":292969,
         "gp:id":2347109,
         "hasc:id":"AE.AZ",
+        "iso:code":"AE-AZ",
         "iso:id":"AE-AZ",
         "loc:id":"n81147503",
         "qs_pg:id":218190,
         "wd:id":"Q187712",
         "wk:page":"Emirate of Abu Dhabi"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b2b9fe1603873efa13231262ac6c892e",
+    "wof:geomhash":"f93ee4a9a90b1ae9026e78babece2ab9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -505,7 +507,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690848516,
+    "wof:lastmodified":1695885136,
     "wof:name":"Abu Dhabi",
     "wof:parent_id":85632573,
     "wof:placetype":"region",

--- a/data/856/679/83/85667983.geojson
+++ b/data/856/679/83/85667983.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"1971-12-02",
     "geom:area":0.377301,
-    "geom:area_square_m":4217541251.496352,
+    "geom:area_square_m":4230617399.657543,
     "geom:bbox":"54.649697,24.595088,56.204439,25.358089",
     "geom:latitude":24.932029,
     "geom:longitude":55.367232,
@@ -668,12 +668,14 @@
         "gn:id":292224,
         "gp:id":2347111,
         "hasc:id":"AE.DU",
+        "iso:code":"AE-DU",
         "iso:id":"AE-DU",
         "qs_pg:id":1278641,
         "unlc:id":"AE-DU",
         "wd:id":"Q613",
         "wk:page":"Emirate of Dubai"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1376833603
     ],
@@ -681,7 +683,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"995357e10706011ac955020ac14963ff",
+    "wof:geomhash":"aa65aaecdcc88def897394935872ab6b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -696,7 +698,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690848517,
+    "wof:lastmodified":1695885136,
     "wof:name":"Dubai",
     "wof:parent_id":85632573,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.